### PR TITLE
Javascript parsers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,9 +25,23 @@ test {
     useTestNG()
 }
 
+// Add a new source set so we can generate javascript from it (note: anltrjs mirrors main antlr sourceset)
+sourceSets {
+    antlrJS {
+        antlr {
+            srcDirs = ["src/main/antlr"]
+        }
+    }
+}
+
 generateGrammarSource {
     outputDirectory = file("src/generated/java/org/mitre/shr/antlr")
     arguments += ["-visitor", "-long-messages", '-package', 'org.mitre.shr.antlr']
+}
+
+generateAntlrJSGrammarSource {
+    outputDirectory = file(getSHRJSParsersDir())
+    arguments += ["-visitor", "-long-messages", '-Dlanguage=JavaScript']
 }
 
 clean {
@@ -38,6 +52,15 @@ sourceSets.main.java.srcDirs += file("src/generated/java")
 
 idea {
   module {
-    generatedSourceDirs += file('${projectDir}/src/generated/java')
+    generatedSourceDirs += file("${projectDir}/src/generated/java")
   }
+}
+
+def String getSHRJSParsersDir()
+{
+   if (hasProperty('shr.js.parsers.dir'))
+   {
+      return this.properties['shr.js.parsers.dir']
+   }
+   return "${projectDir}/build/javascript/parsers"
 }

--- a/src/main/antlr/SHRLexer.g4
+++ b/src/main/antlr/SHRLexer.g4
@@ -46,8 +46,9 @@ CODE:               '#' [0-9a-zA-z\\-]+;
 WHOLE_NUMBER:       [0-9]+;
 ALL_CAPS:           [A-Z][A-Z0-9]*;
 UPPER_WORD:         [A-Z][0-9a-zA-Z\\-]*;
-LOWER_WORD:         [a-z][0-9a-zA-z\\-]*;
-DOT_SEPARATED_LW:   [a-z][0-9a-zA-z\\-]* ('.' [a-z][0-9a-zA-z\\-]*)+;
+LOWER_WORD:         [a-z][0-9a-zA-Z\\-]*;
+DOT_SEPARATED_LW:   [a-z][0-9a-zA-Z\\-]* ('.' [a-z][0-9a-zA-z\\-]*)+;
+DOT_SEPARATED_UW:   [a-z][0-9a-zA-Z\\-]* ('.' [A-Z][0-9a-zA-z\\-]*)+;
 STRING:             '"' (~[\\"])* '"';
 
 // THINGS WE GENERALLY IGNORE

--- a/src/main/antlr/SHRParser.g4
+++ b/src/main/antlr/SHRParser.g4
@@ -32,14 +32,16 @@ concept:            ALL_CAPS CODE;
 descriptionProp:    KW_DESCRIPTION COLON STRING;
 answerProp:         KW_ANSWER COLON answers;
 answers:            answer (COMMA answer)*;
-answer:             dataElementName | primitive;
+answer:             dataElementRef | entryRef | primitive;
 valuesetProp:       KW_VALUESET COLON URL;
 bindingProp:        KW_BINDING COLON KW_REQUIRED; // TODO: Define more bindings
 hasProp:            (KW_HAS COLON)? countedThings;
 
+dataElementRef:     LOWER_WORD | DOT_SEPARATED_LW;
+entryRef:           UPPER_WORD | DOT_SEPARATED_UW;
 primitive:          KW_BOOLEAN | KW_INTEGER | KW_STRING | KW_DECIMAL | KW_URI | KW_BASE64_BINARY | KW_INSTANT | KW_DATE
                     | KW_DATE_TIME | KW_TIME | KW_CODE | KW_OID | KW_ID | KW_MARKDOWN | KW_UNSIGNED_INT
                     | KW_POSITIVE_INT;
 
 countedThings:      countedThing+;
-countedThing:       WHOLE_NUMBER RANGE (WHOLE_NUMBER|STAR) dataElementName;
+countedThing:       WHOLE_NUMBER RANGE (WHOLE_NUMBER | STAR) (dataElementRef | entryRef);


### PR DESCRIPTION
This pull request brings in support for generating javascript parsers and lexers.  It also brings in a few minor corrections to the grammar.

To generate the javascript parsers to `/path/to/parsers`, issue the following gradle command:
```
gradle -Pshr.js.parsers.dir=/path/to/parsers generateAntlrJSGrammarSource
```
