### PR TITLE
Annotated ValueSet for MultipleBirth with MTH CUIs for VS members

### DIFF
--- a/spec/shr_identification_vs.txt
+++ b/spec/shr_identification_vs.txt
@@ -21,13 +21,14 @@ ValueSetDefinition: http://standardhealthrecord.org/identification/vs/HumanNameS
 #phd:   "Ph.D"
 
 ValueSetDefinition: http://standardhealthrecord.org/identification/vs/MultipleBirth
-#no:                    "No (single)"
-#identical-twin:        "Identical Twin"
-#fraternal-twin:        "Fraternal Twin"
-#triplet:               "Triplet"
-#quadruplet:            "Quadruplet"
-#quintuplet:            "Quintuplet"
-#multiple-unspecified:  "Multiple, Unspecified"
+#no:                    "No (Singleton)"            //Concept:        MTH #C1313913     
+#identical-twin:        "Identical Twin"            //Concept:        MTH #C0041432 
+#fraternal-twin:        "Fraternal Twin"            //Concept:        MTH #C0041429 
+#triplet:               "Triplet"                   //Concept:        MTH #C0041095 
+#quadruplet:            "Quadruplet"                //Concept:        MTH #C0034373 
+#quintuplet:            "Quintuplet"                //Concept:        MTH #C0034438 
+#multiple-unspecified:  "Multiple, Unspecified"     //Concept:        MTH #C0032989
+// #multiple-morethanquad:  "Multiple, greater than quadrulplets" //Concept:        MTH #C2977454
 
 ValueSetDefinition: http://standardhealthrecord.org/identification/vs/AdministrativeGender
 #male:      "Male"


### PR DESCRIPTION
Annotated ValueSet for MultipleBirth with MTH CUIs for VS members

Does it make sense to leverage CUIs whenever available?
What if the class of CUIs contains members who semantic relations within MTH are not identical? (E.g. "Singleton" in this case derives from a different semantic branch than the others)
What if the "Parent Concept" for a value set has no corresponding CUI, which is the case here. (E.g. There is no LOINC concept for "Were you a product of a multiple pregnancy?" I cannot really think of the medical term for "The state of having one or more siblings born at the same delivery as you, living or dead?" Should that indicate that this term is out of scope for SHR?) 

Also ...It is really hard to explore MTH via the UMLS browser.
