### PR TITLE
Fix ANTLR4 grammar for 'Uses'

### DIFF
--- a/src/main/antlr/SHRParser.g4
+++ b/src/main/antlr/SHRParser.g4
@@ -6,11 +6,10 @@ shr:                dataDefsDoc | valuesetDefsDoc /* | contentProfiles*/;
 
 // DATA DEFINITIONS (Vocabularies, Entries, Elements)
 
-dataDefsDoc:        dataDefsHeader usesStatements* dataDefs;
+dataDefsDoc:        dataDefsHeader usesStatement? dataDefs;
 dataDefsHeader:     KW_DATA_DEFINITIONS namespace;
 
-usesStatements:     usesStatement+;
-usesStatement:      KW_USES namespace;
+usesStatement:      KW_USES namespace (COMMA namespace)*;
 
 dataDefs:           dataDef+;
 dataDef:            vocabularyDef | elementDef | entryDef;
@@ -43,7 +42,7 @@ descriptionProp:    KW_DESCRIPTION STRING;
 
 // VALUESET DEFINITIONS
 
-valuesetDefsDoc:    valuesetDefsHeader valuesetDefs;
+valuesetDefsDoc:    valuesetDefsHeader usesStatement? valuesetDefs;
 valuesetDefsHeader:  KW_VALUESET_DEFINITIONS namespace;
 
 valuesetDefs:       valuesetDef+;


### PR DESCRIPTION
Fix grammar to reflect that `Uses:` puts all used namespaces in a single comma-separated statement.  Also allow `Uses:` for value set def files.