### PR TITLE
Grammar dec 2016 fixes

### DIFF
--- a/spec/shr_actor.txt
+++ b/spec/shr_actor.txt
@@ -1,7 +1,6 @@
 DataDefinitions:	shr.actor
 Uses:				shr.core, shr.demographics
 
-Path: 		http://standardhealthrecord.org/actors/vs
 Path:     	FHIR = http://hl7.org/fhir/ValueSet
 
 /*

--- a/spec/shr_adverse.txt
+++ b/spec/shr_adverse.txt
@@ -14,9 +14,9 @@ Description:	"An instance of an adverse reaction attributed to exposure to a sub
 0..1			Onset
 1..*			SymptomReported // Normally, a MedDRA code!
 0..1			Description   // from core
-//0..1			PatternOfEvent  // from STDM
+0..1			TBD "PatternOfEvent"  // from STDM
 1..1			AllergenIrritant  // Specific substance or pharmaceutical product considered to be responsible for event
-//0..1			AssociatedStudy
+0..1			TBD "AssociatedStudy"
 0..1			AttributionCertainty
 //ActionTakenWithMedication
 //OtherActionTaken

--- a/spec/shr_adverse.txt
+++ b/spec/shr_adverse.txt
@@ -1,10 +1,10 @@
 DataDefinitions:	shr.adverse
+Uses:				shr.core, shr.allergy
 
-	
 /*------------------  Adverse Reaction  -------------------
-   
-   An instance of an adverse reaction to any substance. 
-   
+
+   An instance of an adverse reaction to any substance.
+
 -----------------------------------------------------------------------------*/
 
 
@@ -12,11 +12,11 @@ EntryElement:	AdverseReactionToSubstance
 Concept:		MTH#C0559966 "Adverse reaction to substance"
 Description:	"An instance of an adverse reaction attributed to exposure to a substance. It is not necessarily associated with a previously-recorded SubstanceRisk. This Entry could be used to record an adverse reaction to an immunization or food."
 0..1			Onset
-1..*			Symptom // Normally, a MedDRA code!
+1..*			SymptomReported // Normally, a MedDRA code!
 0..1			Description   // from core
-0..1			PatternOfEvent  // from STDM
-1..1			Substance  // Specific substance or pharmaceutical product considered to be responsible for event
-0..1			AssociatedStudy 
+//0..1			PatternOfEvent  // from STDM
+1..1			AllergenIrritant  // Specific substance or pharmaceutical product considered to be responsible for event
+//0..1			AssociatedStudy
 0..1			AttributionCertainty
 //ActionTakenWithMedication
 //OtherActionTaken
@@ -30,5 +30,5 @@ Description:	"An instance of an adverse reaction attributed to exposure to a sub
 	Value:			Coding from http://hl7.org/fhir/reaction-event-certainty
 
 
-	
+
 //AdverseEvent -- TBD

--- a/spec/shr_allergy.txt
+++ b/spec/shr_allergy.txt
@@ -41,7 +41,7 @@ Description:	"A statement pertaining to an individual's allergies and intoleranc
 		Element:		ExpectedManifestation
 		Concept:		TBD
 		Description:	"Expected or usual symptoms of a disease or condition"
-		Value:			Symptom // from core
+		Value:			SymptomReported // from core
 
 		Element:		Criticality
 		Concept:		MTH#C3858539 "Criticality"

--- a/spec/shr_base.txt
+++ b/spec/shr_base.txt
@@ -7,54 +7,54 @@ Uses:				shr.core, shr.demographics, shr.actor
 Element:		Entry
 Concept:		TBD
 Description:	"Metadata elements added to entries in the SHR, describing the identification, timing, attribution, and other circumstances involved in an SHR entry"
-1..1    		EntryID 
-1..1			StandardHealthRecordID 
+1..1    		EntryID
+1..1			StandardHealthRecordID
 1..1			PersonOfRecordID
 1..1			FocalSubject   // usually the person of record, but could be a fetus, a family member, etc.
 0..1			EncounterOfEntry
 1..1    		DateEntered  // Creation of the entry
 0..*			DateUpdated
 0..*    		InformationOriginator   // person or entity that provided the information in the entry
-0..*			InformationResponsiblePerson  
-0..1			LanguageOfEntry 
-0..1			Summary 
-1..1			Version 
+0..*			InformationResponsiblePerson
+0..1			Language
+0..1			Summary
+1..1			Version
 
 	Element:    	EntryID
 	Concept:        MTH#C0600091
 	Description:    "A unique, persistent, permanent identifier for an entry in a health record"
 	Value:          id
-	
+
 	Element: 		PersonOfRecordID
 	Concept:		MTH#C0030705
 	Description:	"The persistent, unique ID of the person described by and tracked by this record. This ID has no intrinsic meaning and should not contain any identifiable information, such a mashup of name and birth date."
 	Value:			id
-	
+
 	Element:		FocalSubject
 	Concept:		TBD
 	Description:	"The person or thing that this entry refers to. Note that not all entries refer to the Subject of SHR (the Person of Record). For example, the entry could refer to a fetus, care giver, or relative (living or dead)"
 	Value:			CareProfessional or FamilyMember or UnrelatedThirdParty  //?? How to refer to the Person of record? Organ donor? Fetus (if recorded as a separate person)?
-	
+
 	Element:		DataElement
 	Concept:		TBD
 	Description:	"The SHR data element identifier, for example, http://standardhealthrecord.org/allergy/SubstanceRisk"
 	Value:			uri
-	
+
 	Element:		EncounterOfEntry
 	Concept:		TBD
 	Description:	"The encounter or episode of care that led to creation of this entry"
-	Value:			Encounter   // TODO
+	Value:			TBD // Encounter   // TODO
 
 	Element:   	 	DateEntered
 	Concept:        MTH#C3669169
 	Description:    "The point in time when the information was recorded in the system of record."
 	Value:          dateTime
-	
+
 	Element: 		DateUpdated
 	Concept:		TBD
 	Description:	"A date that the entry was changed"
 	Value:			dateTime
-	
+
 	Element:    	InformationOriginator
 	Concept:        MTH#C0449416
 	Description:    "From whom or what the information originates, as distinct from the actor creating the entry, e.g. the subject (patient), medical professional, family member, device or software program."
@@ -63,21 +63,21 @@ Description:	"Metadata elements added to entries in the SHR, describing the iden
 	Element:		InformationResponsiblePerson
 	Concept:		TBD
 	Description:	"The person who is responsible for (and may certify) the content of the entry."
-	Value:			CareProfessional or FamilyMember or UnrelatedThirdParty // or PersonOfRecord 
-	
+	Value:			CareProfessional or FamilyMember or UnrelatedThirdParty // or PersonOfRecord
+
 	Element:		Language
 	Concept:		MTH#C0023008
 	Description: 	"A human language, spoken or written"
 	Value:			Coding from http://hl7.org/fhir/ValueSet/languages
 
-		
+
 //-------------- Header Entry Concerning the SHR as a Whole ------------------
 
 EntryElement:	ShrHeader
 Concept:		TBD
 Description:	"Basic information about the SHR and the subject"
 1..1			StandardHealthRecordID
-1..1			SubjectID
+1..1			PersonOfRecordID
 1..1			Anonymized
 1..1			FictionalPerson
 
@@ -101,7 +101,7 @@ Element:		ContributingRecord
 Concept: 		TBD
 Description:	"A health record used to help populate the current health record"
 1..1			HealthRecordID
-1..1			ContentAttribution
+//1..1			ContentAttribution
 1..1			AccessTime
 
 	Element:		HealthRecordID
@@ -115,12 +115,12 @@ Description:	"A health record used to help populate the current health record"
 	Value:			dateTime
 
 
-//-------------  Base for simple (non-lab) observations ---------------------	
+//-------------  Base for simple (non-lab) observations ---------------------
 
 //DegreeOfCertainty
 //DateOfObservation
 
-	
+
 //-------------- Base structure for Test Requests and Results(diagnostic measurements, tests, vital signs, radiology, etc.) -------------
 
 Element: 		Test
@@ -131,7 +131,7 @@ Value: 			TestCode
 0..1 			SpecimenType
 0..1			TestMethod
 0..1 			BodyPosition
-0..1 			Device 
+//0..1 			Device
 0..*			Qualifier
 
 		Element:		TestCode
@@ -148,11 +148,11 @@ Value: 			TestCode
 		Concept:		MTH#C1299991
 		Description:	"The technique used to carry out a procedure, if not implicit in the test code"
 		Value:			Coding
-		
+
 		Element:		Qualifier
 		Concept:		MTH#C1443279
 		Description:	"A description of the conditions or context of a test, for example, under sedation, fasting or post-exercise. Note that body position and body site are also qualifiers, but handled separately. A qualifier cannot modify the measurement type; for example, a fasting blood sugar is still a blood sugar."
-		Value:			Coding 
+		Value:			Coding
 
 
 EntryElement:	TestRequest
@@ -181,39 +181,39 @@ Description:	"A record of a request for a diagnostic investigation service to be
 		Element:		TestTiming
 		Concept:		TBD
 		Description:	"When test or tests should be done. If the tests are a series or recur (e.g. daily blood sugar testing in the morning) then a Timing can be used to describe the periodicity."
-		Value:			(dateTime or Period or Timing)
-		
+		Value:			(dateTime or Period /*or Timing*/)
+
 		Element:		PriorityOfRequest
 		Concept:		TBD
 		Description:	"Urgency level for which results must be reported to the requestor or responsible individual"
 		Value:			Coding from RequestPriorityVS
-		
+
 		Element:		RequestedPerformerType
 		Concept:		TBD
 		Description:	"What type of actor should carry out the testing"
 		Value:			TBD
-		
+
 		Element:		RequestedPerformer
 		Concept:		TBD
 		Description:	"Who should carry out the tests. For example, the patient or caregiver"
-		Value:			HealthcareActor // How can we refer to the Person of Record here? The organ or egg donor? 
-		
+		Value:			HealthcareActor // How can we refer to the Person of Record here? The organ or egg donor?
+
 		Element:		ReasonForRequest
 		Concept:		TBD
 		Description:	"The justification for this order, which may be because the subject is at risk for a disease, as part of a diagnostic process, due to a symptom or problem, a part of a care plan, or periodic monitoring"
 		Value:			TBD
-		
+
 		Element:		PerformerInstructions
 		Concept:		TBD
 		Description:	"Information for the performer of the test, if needed."
 		Value:			string
-		
+
 		Element:		PatientInstructions
 		Concept:		TBD
 		Description:	"Information for the patient, such as, where to get the test, how to prepare for the test, etc."
 		Value:			string
 
-		
+
 EntryElement:	TestResult
 Concept:		MTH#C0456984
 Description:	"The result of a laboratory, radiologic, or other clinical test or measurement performed to determine the presence, absence, or degree of a condition or assess the health of an individual."
@@ -221,7 +221,7 @@ Value:			(Quantity or Coding)
 1..1			Test
 1..*			Performer   //from actor
 1..1			(TestTime or TestPeriod)
-0..1 			Interpretation
+0..1 			TestInterpretation
 0..1			ChangeFlag
 0..1			TestRequest  // optional reference back to the request
 
@@ -229,24 +229,24 @@ Value:			(Quantity or Coding)
 	Concept:		TBD
 	Description:	"The time at which a measurement was taken or specimen collected."
 	Value:			dateTime
-	
+
 	Element:		TestPeriod
 	Concept:		TBD
 	Description:	"The start and end times for a measurement, if observed over a period of time, or the start and end of the specimen collection, if collected over a significant period of time (e.g. 24 hour Urine Sodium)."
 	Value:			Period
-	
+
 	Element:		TestInterpretation
 	Concept:		TBD
 	Description:	"A clinical interpretation of a measurement"
 	Value:			Coding from TestInterpretationVS
-	
+
 	Element:		ChangeFlag
 	Concept:		TBD
 	Description:	"Indicator of change from the last or previous measurement."
 	Value:			Coding from ChangeFlagVS
-	
-	
-	
+
+
+
 //------------------ Action or Inaction ----------------------
 
 //Action "ClinicalEntry"

--- a/spec/shr_base.txt
+++ b/spec/shr_base.txt
@@ -43,7 +43,7 @@ Description:	"Metadata elements added to entries in the SHR, describing the iden
 	Element:		EncounterOfEntry
 	Concept:		TBD
 	Description:	"The encounter or episode of care that led to creation of this entry"
-	Value:			TBD // Encounter   // TODO
+	Value:			TBD "Encounter"
 
 	Element:   	 	DateEntered
 	Concept:        MTH#C3669169
@@ -101,7 +101,7 @@ Element:		ContributingRecord
 Concept: 		TBD
 Description:	"A health record used to help populate the current health record"
 1..1			HealthRecordID
-//1..1			ContentAttribution
+1..1			TBD "ContentAttribution"
 1..1			AccessTime
 
 	Element:		HealthRecordID
@@ -131,7 +131,7 @@ Value: 			TestCode
 0..1 			SpecimenType
 0..1			TestMethod
 0..1 			BodyPosition
-//0..1 			Device
+0..1 			TBD "Device"
 0..*			Qualifier
 
 		Element:		TestCode
@@ -181,7 +181,7 @@ Description:	"A record of a request for a diagnostic investigation service to be
 		Element:		TestTiming
 		Concept:		TBD
 		Description:	"When test or tests should be done. If the tests are a series or recur (e.g. daily blood sugar testing in the morning) then a Timing can be used to describe the periodicity."
-		Value:			(dateTime or Period /*or Timing*/)
+		Value:			(dateTime or Period or TBD "Timing")
 
 		Element:		PriorityOfRequest
 		Concept:		TBD

--- a/spec/shr_demographics.txt
+++ b/spec/shr_demographics.txt
@@ -80,7 +80,7 @@ Value:			string
 	Element:		StateOfIssue
 	Concept:		MTH#C1547728
 	Description:	"Issuing authority for a drivers license"
-	Value:			UnitedStatesState
+	Value:			State // UnitedStatesState
 
 EntryElement:	PassportNumber
 Concept:		MTH#C1549737
@@ -104,7 +104,7 @@ Value: 			Coding from InsuranceProviderTypeVS
 	Element:	 	InsuranceMemberId
 	Concept:		TBD
 	Description:	"Patient identifier at a healthcare provider, insurer, or other related organization."
-	1..1			Identifier
+	Value:			id
 
 // ------------------------- Residence Address ----------------------
 

--- a/spec/shr_encounter.txt
+++ b/spec/shr_encounter.txt
@@ -1,5 +1,5 @@
 DataDefinitions:	shr.encounter
-Uses:				shr.core, shr.base
+Uses:				shr.core, shr.base, shr.demographics, shr.actor
 
 
 Element:		Facility
@@ -23,12 +23,12 @@ Value:			FacilityName
 	0..1			Address
 	0..1 			Geoposition
 	0..1 			GeopoliticalLocation
-	
+
 	Element:		MobileFacility
 	Concept:		MTH#C0231435
 	Description:	"A facility that moves from place to place, such as Meals-On-Wheels"
 	Value:			boolean
-	
+
 	Element:		ManagingOrganization
 	Concept:		MTH#C0677351
 	Description:	"The organization that manages the operation of an activity, facility, or service provision"
@@ -54,19 +54,19 @@ Description:	"An interaction between a patient and healthcare provider(s) for th
 	Description:	"Whether a medical interpreter is needed to facilitate communication"
 	Value:			boolean
 	1..1			Language
-	
-	
-	
+
+
+
 
 	EntryElement:	PaymentSource
 	Concept:		MTH#C0680269
 	Description:	"The source of payment for the current encounter"
-	Value:			PaymentSourceVS //TBD
-	
-	
-	
-/*	
-Hospitalization		
+	Value:			TBD // PaymentSourceVS //TBD
+
+
+
+/*
+Hospitalization
 	DateTime	Period
 	Location	Reference
 	Organization	Reference
@@ -79,8 +79,8 @@ Hospitalization
 	Discharge Services	Multi Enum
 	Discharge or Transfer Destination	?
 	Discharge Summary	Document
-		
-Emergency Encounter		
+
+Emergency Encounter
 	DateTime	Period
 	Location	Reference
 	Organization	Reference

--- a/spec/shr_encounter.txt
+++ b/spec/shr_encounter.txt
@@ -61,7 +61,7 @@ Description:	"An interaction between a patient and healthcare provider(s) for th
 	EntryElement:	PaymentSource
 	Concept:		MTH#C0680269
 	Description:	"The source of payment for the current encounter"
-	Value:			TBD // PaymentSourceVS //TBD
+	Value:			TBD "PaymentSourceVS"
 
 
 

--- a/spec/shr_familyhistory.txt
+++ b/spec/shr_familyhistory.txt
@@ -1,12 +1,13 @@
-DataDefinitions:      shr.familyhistory
+DataDefinitions:    shr.familyhistory
+Uses:               shr.actor, shr.demographics
 
 EntryElement:	FamilyHistory
 Description:	"Health history of a person related to the person of record"
 1..1			FamilyMember
 1..1			DateOfBirth
 0..1    		PlaceOfBirth
-1..1			AgeAtDeath // TBD
-1..*    		FamilyHistoryCondition // TBD
-0..*    		FamilyHistoryConditionExclusion // TBD
-0..*    		ExternalHealthRecord //TBD
+//1..1			AgeAtDeath // TBD
+//1..*    		FamilyHistoryCondition // TBD
+//0..*    		FamilyHistoryConditionExclusion // TBD
+//0..*    		ExternalHealthRecord //TBD
 // TODO: genomic informationn

--- a/spec/shr_familyhistory.txt
+++ b/spec/shr_familyhistory.txt
@@ -6,8 +6,8 @@ Description:	"Health history of a person related to the person of record"
 1..1			FamilyMember
 1..1			DateOfBirth
 0..1    		PlaceOfBirth
-//1..1			AgeAtDeath // TBD
-//1..*    		FamilyHistoryCondition // TBD
-//0..*    		FamilyHistoryConditionExclusion // TBD
-//0..*    		ExternalHealthRecord //TBD
+1..1			TBD "AgeAtDeath"
+1..*    		TBD "FamilyHistoryCondition"
+0..*    		TBD "FamilyHistoryConditionExclusion"
+0..*    		TBD "ExternalHealthRecord"
 // TODO: genomic informationn

--- a/spec/shr_immunization.txt
+++ b/spec/shr_immunization.txt
@@ -2,72 +2,72 @@ DataDefinitions:	shr.immunization
 Uses:				shr.core, shr.medication
 
 Vocabulary:    		MVX = urn:oid:2.16.840.1.114222.4.11.826  // oid-based identifier for vaccine manufacturer in phin-vads
-Vocabulary:    		CVX = http://hl7.org/fhir/ValueSet/vaccine-code 
+Vocabulary:    		CVX = http://hl7.org/fhir/ValueSet/vaccine-code
 
 Element:		Vaccine
 Concept:		MTH#C1543322
 Description:	"A specific type or manufactured instance of a vaccine, a prophylactic or therapeutic preparation given to produce immune response to pathogenic organisms or substances."
 Value:			Coding from CVX
 0..1			VaccineManufacturer
-0..1			LotNumber	
+0..1			LotNumber
 
 	Element:		VaccineManufacturer
 	Concept:		MTH#C1114744
 	Description:	"The organization that produces the vaccine"
 	Value:			Coding from MVX
-	
+
 	Element:		LotNumber
 	Concept:		MTH#C1115660
 	Description:	"A distinctive alpha-numeric identification code assigned by the manufacturer or distributor to a specific quantity of manufactured material or product within a batch."
 	Value:			string
-	
+
 EntryElement:	ImmunizationAdministered
 Concept:		MTH#C0020971
 Description:	"A record of a vaccination that is or has been administered to the subject."
 1..1 			Vaccine   // has type, lot, manufacturer
 0..1			BodySite   // from core
-0..1			AdminstrationRoute    // from medication
+//0..1			AdminstrationRoute    // from medication
 0..1			AmountOfMedication  // from medication
-0..1			DoseSequenceNumber
+//0..1			DoseSequenceNumber
 
 
-EntryElement:	ImmunizatonNotAdministered 
+EntryElement:	ImmunizatonNotAdministered
 Concept:		TBD
 Description:	"Immunization that was not given to the subject."
 1..1 			Vaccine
-0..1			DoseSequenceNumber   // which dose was missed
+//0..1			DoseSequenceNumber   // which dose was missed
 1..1			ImmunizationNotAdministeredReason //e.g., refused, no supply, patient didn't show up, etc.
 
 	Element:		ImmunizationNotAdministeredReason
 	Concept:		TBD
 	Description:	"Reason the scheduled or intended immunization was not given"
-	Value:			Coding from http://hl7.org/fhir/ValueSet/no-immunization-reason 
+	Value:			Coding from http://hl7.org/fhir/ValueSet/no-immunization-reason
 
-EntryElement:	ImmunizationRecommended 
+EntryElement:	ImmunizationRecommended
 1..1			Vaccine
-0..1			DoseNumber
+//0..1			DoseNumber
 1..1			TargetDateRange
 
 	Element:		TargetDateRange
 	Concept:		TBD
 	Description:	"Dates between which when a future event should occur"
 	Value:			Period
-	
-EntryElement:	ImmunizationRecommendedAgainst 
+
+EntryElement:	ImmunizationRecommendedAgainst
 1..1			Vaccine
-0..1			(Route or Protocol)
+0..1			AdministrationRoute /*or Protocol*/
 1..1			ReasonMedicationNotGiven  // From shr_medication_vs
 
 
 
 /*
 add list of high risk conditions which alter the schedule. Military might get anthrax or other special vaccines
-How about other prophylactics, e.g. For malaria?						
-						
+How about other prophylactics, e.g. For malaria?
+
 Tetanus (Td)						every 10 years
 With Pertussius (Tdap)						1 dose unless pregnant then booster each pregnancy
 Vericella (Chicken Pox) shot or illness						2 doses
-Pneumovax (pneumonia)						
+Pneumovax (pneumonia)
 Influenza (flu shot)						annual; IIV or LIAV route
 Hepatitis A						2 doses
 Hepatitis B						3 doses
@@ -80,15 +80,15 @@ DTaP						5 doses
 HiB						3-4 doses
 PCV13						4 doses as child; one age 65
 IPV						4doses
-Pneumococcal polysaccharide (PPSV23)						
+Pneumococcal polysaccharide (PPSV23)
 MPSV4						1 or more doses
 Meningococcus B						2 or 3 doses
-						
-Contraindications						
-pregnancy, immunocompromized or HIV CD4 cound <200--varicella, zoster, and MMR						
-others with special recommendations: MSM, renal failure/ESRD on dialysis; heart dz; chronic lung dz; Etoh'ism; asplenia; chronic liver fzl DM; healthcare worker						
-						
-						
-Susan: Immunizations--both history per SHR v0.2 and confirmation that ones due during pregnancy are given. TDaP; flu for everyone.  If indicated Hep A, Hep B, meningococcal, pneumococcal. Rhogam at 28 weeks if indicted and other times in pregnancy if indicated.  If patient is not immune needs Varicella and MMR postpartum-----and way to flag that in the SHR with notification triggered by birth.						
-						
+
+Contraindications
+pregnancy, immunocompromized or HIV CD4 cound <200--varicella, zoster, and MMR
+others with special recommendations: MSM, renal failure/ESRD on dialysis; heart dz; chronic lung dz; Etoh'ism; asplenia; chronic liver fzl DM; healthcare worker
+
+
+Susan: Immunizations--both history per SHR v0.2 and confirmation that ones due during pregnancy are given. TDaP; flu for everyone.  If indicated Hep A, Hep B, meningococcal, pneumococcal. Rhogam at 28 weeks if indicted and other times in pregnancy if indicated.  If patient is not immune needs Varicella and MMR postpartum-----and way to flag that in the SHR with notification triggered by birth.
+
 */

--- a/spec/shr_immunization.txt
+++ b/spec/shr_immunization.txt
@@ -26,16 +26,16 @@ Concept:		MTH#C0020971
 Description:	"A record of a vaccination that is or has been administered to the subject."
 1..1 			Vaccine   // has type, lot, manufacturer
 0..1			BodySite   // from core
-//0..1			AdminstrationRoute    // from medication
+0..1			AdministrationRoute  // from medication
 0..1			AmountOfMedication  // from medication
-//0..1			DoseSequenceNumber
+0..1			TBD "DoseSequenceNumber"
 
 
 EntryElement:	ImmunizatonNotAdministered
 Concept:		TBD
 Description:	"Immunization that was not given to the subject."
 1..1 			Vaccine
-//0..1			DoseSequenceNumber   // which dose was missed
+0..1			TBD "DoseSequenceNumber"   // which dose was missed
 1..1			ImmunizationNotAdministeredReason //e.g., refused, no supply, patient didn't show up, etc.
 
 	Element:		ImmunizationNotAdministeredReason
@@ -45,7 +45,7 @@ Description:	"Immunization that was not given to the subject."
 
 EntryElement:	ImmunizationRecommended
 1..1			Vaccine
-//0..1			DoseNumber
+0..1			TBD "DoseNumber"
 1..1			TargetDateRange
 
 	Element:		TargetDateRange
@@ -55,7 +55,7 @@ EntryElement:	ImmunizationRecommended
 
 EntryElement:	ImmunizationRecommendedAgainst
 1..1			Vaccine
-0..1			AdministrationRoute /*or Protocol*/
+0..1			(AdministrationRoute or TBD "Protocol")
 1..1			ReasonMedicationNotGiven  // From shr_medication_vs
 
 

--- a/spec/shr_lifehistory.txt
+++ b/spec/shr_lifehistory.txt
@@ -1,4 +1,5 @@
-DataDefinitions:      shr.lifehistory
+DataDefinitions:    shr.lifehistory
+Uses:				shr.core, shr.base
 
 EntryElement:	PrenatalExposure
 Concept:		MTH#C0871747

--- a/spec/shr_medication.txt
+++ b/spec/shr_medication.txt
@@ -12,36 +12,36 @@ Concept:		MTH#C0013227
 Description:	"A type of prescription drug or over-the-counter drug that is used to prevent, treat, or relieve symptoms of a disease or abnormal condition, but excluding vaccines."
 1..1 			SpecificCode with Coding from RXN
 0..1			DoseForm
-0..1			MedicationStrength 
+0..1			MedicationStrength
 0..1			BrandName
 
 		Element:		DoseForm
 		Concept:		MTH#C0013058
 		Description:	"The form in which active and/or inert ingredient(s) are physically presented"
-		Value:			Coding from FHIR/medication-form-codes 
-		
+		Value:			Coding from FHIR/medication-form-codes
+
 		Element:		MedicationStrength
 		Concept:		MTH#C3176062
 		Description:	"Specifies how many (or how much) of the active ingredient there is in this Medication, to be interpreted as a ratio. For example, 250 mg per tablet. This is expressed as a ratio where the numerator is 250mg and the denominator is 1 tablet."
 		1..1			ActiveIngredientAmount
 		1..1			AmountOfMedication
-		
+
 			Element:		ActiveIngredientAmount
 			Concept:		TBD
 			Description:	"The amount of an active ingredient in a medication"
 			Value:			Quantity
-			
+
 			Element:		AmountOfMedication
 			Concept:		TBD
 			Description:	"A standardized measure or discrete amount of medication serving as a reference for dosing or strength, for example, 1 tablet."
 			Value:			Quantity
-	
+
 		Element:		BrandName
 		Concept:		TBD
 		Description:	"The brand name of a product"
 		Value: 			string
-		
-		
+
+
 EntryElement:	MedicationTaken
 Concept:		TBD
 Description:	"Report of a medication prescribed and/or consumed. Medication use is either reported, directly observed, or inferred from clinical events associated with orders, prescriptions written, pharmacy dispensings, procedural administrations, and other patient-reported information."
@@ -50,7 +50,7 @@ Description:	"Report of a medication prescribed and/or consumed. Medication use 
 0..1			Adherence
 1..1			OccurrencePeriod
 1..1 			ReasonForUse
-	
+
 	Element:		Dosage
 	Concept:		MTH#C0178602
 	Description:	"The dosage of the medication as prescribed"
@@ -63,11 +63,11 @@ Description:	"Report of a medication prescribed and/or consumed. Medication use 
 	0..1			AdministrationMethod
 	0..1			AdministrationBodySite
 	0..*			MaximumDosePerPeriod  // no more than x in any 24-hour period
-	
+
 		Element:		DoseAmountRange
 		Concept:		TBD
 		Description:	"The amount of medication taken at each dose, as a range"
-		Value:			Range 
+		Value:			TBD // Range
 
 		Element:		DoseAmountQuantity
 		Concept:		TBD
@@ -77,48 +77,48 @@ Description:	"Report of a medication prescribed and/or consumed. Medication use 
 		Element:		TimingOfDoses
 		Concept:		TBD
 		Description:	"When doses of medication should be administered"
-		Value:			Timing
-		
+		Value:			TBD // Timing
+
 		Element:		DoseAsNeededIndicator
 		Concept:		MTH#C1883728
 		Description:	"Indicates that a drug or therapy should be used as often as the patient decides it is necessary."
 		Value:			boolean
-		
+
 		Element:		DoseInstructionsText
 		Concept:		TBD
 		Description:	"The directions (signetur) on the drug prescription or dispensing record."
 		Value:			string
-		
+
 		Element:		AdditionalDoseInstruction
 		Concept:		MTH#C1644714
 		Description:	"Supplemental instructions - e.g. 'with meals'"
-		Value:			Coding from FHIR/additional-instructions-codes 
-		
+		Value:			Coding from FHIR/additional-instructions-codes
+
 		Element:		AdministrationRoute
 		Concept:		MTH#C0013153
 		Description:	"How a medication entered or should enter the body"
-		Value:			Coding from FHIR/route-codes 
-		
+		Value:			Coding from FHIR/route-codes
+
 		Element:		AdministrationMethod
 		Concept:		MTH#C1547585
 		Description:	"Technique for administering medication"
-		Value:			Coding from FHIR/administration-method-codes 
-		
+		Value:			Coding from FHIR/administration-method-codes
+
 		Element:		AdministrationBodySite
 		Concept:		MTH#C0229986
 		Description:	"The anatomic site at which medical intervention is applied."
-		Value:			BodySite 
-		
+		Value:			BodySite
+
 		Element:		MaximumDosePerPeriod
 		Concept:		TBD
 		Description:	"The maximum amount of a medication to be taken in a given period of time."
 		1..1			AmountOfMedication
 		1..1			Duration
-			
+
 	Element:		Adherence
 	Concept:		MTH#C2364172
 	Description:	"A statement of the ability and cooperation of the patient in taking medicine or supplement as recommended or prescribed. This includes correct timing, dosage, and frequency."
-	0..*			(MedicationTreatment or SupplementTreatment) // If no medication is given, then the adherence statement is general; it refers to no particular medication(s)
+	//0..*			(MedicationTreatment or SupplementTreatment) // If no medication is given, then the adherence statement is general; it refers to no particular medication(s)
 	1..1			AdherenceLevel
 	0..*			NonAdherenceReason
 	1..1			Details   // from core
@@ -127,18 +127,18 @@ Description:	"Report of a medication prescribed and/or consumed. Medication use 
 		Concept:		MTH#C1510802
 		Description:	"The frequency that the stated treatment plan, prescription, or protocol is followed."
 		Value:			Coding from FiveFrequencyScaleVS
-		
+
 		Element:		NonAdherenceReason
 		Concept:		TBD
 		Description:	"Reason for not following the stated treatment plan, prescription, or protocol."
 		Value:			Coding from MedicationNonAdherenceReasonVS
-		
+
 	Element:		ReasonForUse
 	Concept:		TBD
 	Description:	"The rationale for why the patient receives a medication or prescription"
 	Value:			Explanation   // TODO: add a reference to problem or condition
-		
-	
+
+
 EntryElement:	MedicationNotAdministered
 Concept:		TBD
 Description:	"A record of a medication not prescribed or administered. Recorded only when deviating from the normal expectation, care plan, or standard of care."
@@ -150,7 +150,7 @@ Description:	"A record of a medication not prescribed or administered. Recorded 
 	Concept:		TBD
 	Description:	"The rationale for NOT using particular medication treatment"
 	Value:			Coding from ReasonNotGivenVS
-	
+
 EntryElement:	MedicationChange
 Concept:		MTH#C0554834
 Description:	"Description of a modification or change of a medication or dosage."
@@ -158,20 +158,20 @@ Description:	"Description of a modification or change of a medication or dosage.
 1..1			TypeOfChange
 0..*			MedicationBeforeChange   //might be more than one
 0..*			MedicationAfterChange   // null if medication was discontinued
-1..1			ReasonForMedicationChange
-			
+//1..1			ReasonForMedicationChange
+
 		Element:		TypeOfChange
 		Concept:		TBD
 		Description:	"Whether the change is a dose change, switch to a new medication, or discontinuation"
 		Value:			Coding from MedicationChangeTypeVS
-		
+
 		Element:		MedicationBeforeChange
 		Concept:		TBD
 		Description:	"The medication taken, prior to the change"
 		Value:			MedicationTaken
-		
+
 		Element:		MedicationAfterChange
 		Concept:		TBD
 		Description:	"A medication taken, after the change"
 		Value:			MedicationTaken
-	
+

--- a/spec/shr_medication.txt
+++ b/spec/shr_medication.txt
@@ -67,7 +67,7 @@ Description:	"Report of a medication prescribed and/or consumed. Medication use 
 		Element:		DoseAmountRange
 		Concept:		TBD
 		Description:	"The amount of medication taken at each dose, as a range"
-		Value:			TBD // Range
+		Value:			TBD "Range"
 
 		Element:		DoseAmountQuantity
 		Concept:		TBD
@@ -77,7 +77,7 @@ Description:	"Report of a medication prescribed and/or consumed. Medication use 
 		Element:		TimingOfDoses
 		Concept:		TBD
 		Description:	"When doses of medication should be administered"
-		Value:			TBD // Timing
+		Value:			TBD "Timing"
 
 		Element:		DoseAsNeededIndicator
 		Concept:		MTH#C1883728
@@ -118,7 +118,7 @@ Description:	"Report of a medication prescribed and/or consumed. Medication use 
 	Element:		Adherence
 	Concept:		MTH#C2364172
 	Description:	"A statement of the ability and cooperation of the patient in taking medicine or supplement as recommended or prescribed. This includes correct timing, dosage, and frequency."
-	//0..*			(MedicationTreatment or SupplementTreatment) // If no medication is given, then the adherence statement is general; it refers to no particular medication(s)
+	0..*			(TBD "MedicationTreatment" or TBD "SupplementTreatment") // If no medication is given, then the adherence statement is general; it refers to no particular medication(s)
 	1..1			AdherenceLevel
 	0..*			NonAdherenceReason
 	1..1			Details   // from core
@@ -158,7 +158,7 @@ Description:	"Description of a modification or change of a medication or dosage.
 1..1			TypeOfChange
 0..*			MedicationBeforeChange   //might be more than one
 0..*			MedicationAfterChange   // null if medication was discontinued
-//1..1			ReasonForMedicationChange
+1..1			TBD "ReasonForMedicationChange"
 
 		Element:		TypeOfChange
 		Concept:		TBD

--- a/spec/shr_vital.txt
+++ b/spec/shr_vital.txt
@@ -2,20 +2,20 @@ DataDefinitions:	shr.vital
 Uses:				shr.core, shr.base
 
 Vocabulary:     LNC = http://loinc.org
-Vocabulary:		UCUM = http://unitsofmeasure.org 
+Vocabulary:		UCUM = http://unitsofmeasure.org
 Vocabulary:		MTH = http://uts.nlm.nih.gov/metathesaurus
 
 
 //-------------------  Specific Vital Sign TestResults -----------------------------
-	
+
 EntryElement:	RespiratoryRate
 BasedOn:		TestResult
 Concept:		LNC#9279-1, MTH#C0231832, LNC#8716-3 "Vital Sign"
-Description:	"The rate of breathing (inhalation and exhalation) measured within in a unit time, expressed as breaths per minute."  
+Description:	"The rate of breathing (inhalation and exhalation) measured within in a unit time, expressed as breaths per minute."
 Value:			Quantity with units UCUM#C66967 "/min"
 1..1			TestCode is LNC#9279-1   // could it be a more specific LOINC code??
 0..*			Qualifier with Coding from RespiratoryRateQualifierVS
-0..1			Method with Coding from RespiratoryRateMethodVS
+0..1			TestMethod with Coding from RespiratoryRateMethodVS
 
 EntryElement:	HeartRate
 BasedOn:		TestResult
@@ -24,7 +24,7 @@ Description:	"The number of times the HEART VENTRICLES contract per unit of time
 Value:			Quantity with units UCUM#C66967 "/min"
 1..1			TestCode is LNC#8867-4
 0..*			Qualifier with Coding from HeartRateQualifierVS
-0..1			Method with Coding from HeartRateMethodVS
+0..1			TestMethod with Coding from HeartRateMethodVS
 
 EntryElement:	OxygenSaturation
 BasedOn:		TestResult
@@ -40,7 +40,7 @@ Concept:		LNC#8310-5, MTH#C0005903, LNC#8716-3 "Vital Sign"
 Description:	"The measure of the level of heat in a human or animal."
 Value:			Quantity with units UCUM#C42559 "C"
 1..1			TestCode is LNC#8310-5
-0..1			Method with Coding from BodyTemperatureMethodVS
+0..1			TestMethod with Coding from BodyTemperatureMethodVS
 0..1			Qualifier with Coding from BodyTemperatureQualifierVS
 0..1			BodySite
 
@@ -73,7 +73,7 @@ Concept:		LNC#8287-5
 Description:	"Circumference of the head (typically 0-2 years)"
 Value:			Quantity with units UCUM#C49668 "cm"
 1..1			TestCode is LNC#8287-5
-	
+
 EntryElement:	BodyMassIndex
 BasedOn:		TestResult
 Concept:		LNC#39156-5, MTH#C1305855
@@ -97,10 +97,10 @@ Description:	"The force of circulating blood on the walls of the arteries."
 	Value:			Quantity with units UCUM#49670 "mmHg"
 	1..1			TestCode is LNC#8480-6
 	0..1			BodySite with Coding from BloodPressureBodySiteVS
-	0..1			Method with Coding from BloodPressureMethodVS
+	0..1			TestMethod with Coding from BloodPressureMethodVS
 	0..*			Qualifier with Coding from BloodPressureQualifierVS
 	0..1			HeadTilt
-	
+
 	Element:		DiastolicPressure
 	BasedOn:		TestResult
 	Concept:		LNC#8462-4, MTH#C0428883
@@ -108,10 +108,10 @@ Description:	"The force of circulating blood on the walls of the arteries."
 	Value:			Quantity with units UCUM#49670 "mmHg"
 	1..1			TestCode is LNC#8462-4
 	0..1			BodySite with Coding from BloodPressureBodySiteVS
-	0..1			Method with Coding from BloodPressureMethodVS
+	0..1			TestMethod with Coding from BloodPressureMethodVS
 	0..*			Qualifier with Coding from BloodPressureQualifierVS
 	0..1			HeadTilt
-	
+
 	Element: 		HeadTilt // This is only used during a tilt table test.
 	Concept: 		LNC#8360-0
 	Description:	"The angle at which the head is tilted relative to a level position while physiologic TestResults are taken"

--- a/src/main/antlr/SHRLexer.g4
+++ b/src/main/antlr/SHRLexer.g4
@@ -41,9 +41,9 @@ KW_UNSIGNED_INT:    'unsignedInt';
 KW_POSITIVE_INT:    'positiveInt';
 
 // KEYWORDS for types w/ qualifiers
-KW_CODE_FROM:           'code from';
-KW_CODING_FROM:         'Coding from';
-KW_QUANTITY_WITH_UNITS: 'Quantity with units';
+KW_CODE_FROM:   'code from';
+KW_CODING_FROM: 'Coding from';
+KW_UNITS:       'units';
 
 // SYMBOLS
 DOT:                '.';

--- a/src/main/antlr/SHRParser.g4
+++ b/src/main/antlr/SHRParser.g4
@@ -35,7 +35,7 @@ values:             (value supportingValue*) | (value? supportingValue+);
 value:              KW_VALUE (uncountedValue | countedValue);
 uncountedValue:     (valueType (KW_OR valueType)*) | (OPEN_PAREN valueType (KW_OR valueType)* CLOSE_PAREN);
 countedValue:       count valueType | count OPEN_PAREN valueType (KW_OR valueType)* CLOSE_PAREN;
-valueType:          simpleOrFQName | ref | primitive | codeFromVS | quantityWithUnits | KW_TBD;
+valueType:          simpleOrFQName | ref | primitive | codeFromVS | elementWithConstraint | quantityWithUnits | KW_TBD;
 
 supportingValue:        countedSupportingValue (KW_OR countedSupportingValue)*;
 countedSupportingValue: count (supportingValueType | OPEN_PAREN supportingValueType (KW_OR supportingValueType)* CLOSE_PAREN);

--- a/src/main/antlr/SHRParser.g4
+++ b/src/main/antlr/SHRParser.g4
@@ -35,14 +35,14 @@ values:             (value supportingValue*) | (value? supportingValue+);
 value:              KW_VALUE (uncountedValue | countedValue);
 uncountedValue:     (valueType (KW_OR valueType)*) | (OPEN_PAREN valueType (KW_OR valueType)* CLOSE_PAREN);
 countedValue:       count valueType | count OPEN_PAREN valueType (KW_OR valueType)* CLOSE_PAREN;
-valueType:          simpleOrFQName | ref | primitive | codeFromVS | elementWithConstraint | quantityWithUnits | KW_TBD;
+valueType:          simpleOrFQName | ref | primitive | codeFromVS | elementWithConstraint | tbd;
 
 supportingValue:        countedSupportingValue (KW_OR countedSupportingValue)*;
 countedSupportingValue: count (supportingValueType | OPEN_PAREN supportingValueType (KW_OR supportingValueType)* CLOSE_PAREN);
-supportingValueType:    simpleOrFQName | ref | elementWithConstraint;
+supportingValueType:    simpleOrFQName | ref | elementWithConstraint | tbd;
 
 basedOnProp:        KW_BASED_ON simpleOrFQName;
-conceptProp:        KW_CONCEPT (KW_TBD | concepts);
+conceptProp:        KW_CONCEPT (tbd | concepts);
 concepts:           fullyQualifiedCode (COMMA fullyQualifiedCode)*;
 descriptionProp:    KW_DESCRIPTION STRING;
 
@@ -77,13 +77,14 @@ code:               CODE STRING?;
 fullyQualifiedCode: ALL_CAPS code;
 codeFromVS:         (KW_CODE_FROM | KW_CODING_FROM) valueset;
 elementWithConstraint:      simpleOrFQName (DOT simpleName)* elementConstraint;
-elementConstraint:          elementCodeVSConstraint | elementCodeValueConstraint | elementTypeConstraint;
+elementConstraint:          elementCodeVSConstraint | elementCodeValueConstraint | elementTypeConstraint | elementWithUnitsConstraint;
 elementCodeVSConstraint:    KW_WITH codeFromVS;
 elementCodeValueConstraint: KW_IS fullyQualifiedCode;
 elementTypeConstraint:      KW_IS simpleOrFQName;
-quantityWithUnits:  KW_QUANTITY_WITH_UNITS fullyQualifiedCode;
+elementWithUnitsConstraint: KW_WITH KW_UNITS fullyQualifiedCode;
 valueset:           URL | PATH_URL | URN_OID | simpleName;
 primitive:          KW_BOOLEAN | KW_INTEGER | KW_STRING | KW_DECIMAL | KW_URI | KW_BASE64_BINARY | KW_INSTANT | KW_DATE
                     | KW_DATE_TIME | KW_TIME | KW_CODE | KW_OID | KW_ID | KW_MARKDOWN | KW_UNSIGNED_INT
                     | KW_POSITIVE_INT;
 count:              WHOLE_NUMBER RANGE (WHOLE_NUMBER | STAR);
+tbd:                KW_TBD STRING?;


### PR DESCRIPTION
Fixes bugs in the SHR text definitions based on errors discovered in parsing.  Also adds support for annotating TBD with a string, which allows us to export better documentation.