### PR TITLE
Initial FHIR 3.0.0 mapping updates

### DIFF
--- a/spec/shr_actor_map.txt
+++ b/spec/shr_actor_map.txt
@@ -11,9 +11,9 @@ Practitioner maps to Practitioner:
 	AddressUsed maps to address
 	Telecom maps to telecom
 	LanguageUsed maps to communication
-	Affiliation maps to role.organization  // not exactly
+	// Affiliation maps to role.organization  // 3.0.0 - role removed (use PractitionerRole)
 	NationalProviderIdentifier maps to identifier
-	MedicalSpecialty maps to role.specialty
+	// MedicalSpecialty maps to role.specialty // 3.0.0 - role removed (use PractitionerRole)
 
 Organization maps to Organization:
 	OrganizationName maps to name

--- a/spec/shr_base.txt
+++ b/spec/shr_base.txt
@@ -157,7 +157,7 @@ Description:	"An order for something to take place. Using NonOccurrenceModifier,
 		Element:		RequestStatus
 		Concept:		TBD
 		Description:	"The extent to which the ordering process has progressed, for this order."
-		Value:			code from http://hl7.org/fhir/ValueSet/medication-request-status
+		Value:			code from http://hl7.org/fhir/ValueSet/request-status
 
 		Element:		RequestedPerformanceTime
 		Concept:		TBD
@@ -167,7 +167,7 @@ Description:	"An order for something to take place. Using NonOccurrenceModifier,
 		Element:		PriorityOfRequest
 		Concept:		TBD
 		Description:	"Urgency level for which results must be reported to the requestor or responsible individual."
-		Value:			code from http://hl7.org/fhir/ValueSet/procedure-request-priority
+		Value:			code from http://hl7.org/fhir/ValueSet/request-priority
 
 		Element:		RequestedPerformerType
 		Concept:		TBD

--- a/spec/shr_core_map.txt
+++ b/spec/shr_core_map.txt
@@ -68,9 +68,9 @@ Age maps to Age:
 
 BodySite maps to BodySite:
 	Value maps to code
-	Laterality maps to modifier (slice on = coding.code)
-	Directionality maps to modifier
-	PortionTotality	maps to modifier
+	Laterality maps to qualifier (slice on = coding.code)
+	Directionality maps to qualifier
+	PortionTotality	maps to qualifier
 	Description maps to description
 
 Identifier maps to Identifier:

--- a/spec/shr_device_map.txt
+++ b/spec/shr_device_map.txt
@@ -4,7 +4,7 @@ Target:		FHIR_STU_3
 
 Device maps to Device:
 	Value maps to type
-	DeviceUdi maps to udiCarrier.value
+	DeviceUdi maps to udi.carrierHRF
 	VendorModelNumber maps to model
 
 DeviceUse maps to DeviceUseStatement:

--- a/spec/shr_encounter_map.txt
+++ b/spec/shr_encounter_map.txt
@@ -15,7 +15,7 @@ Facility maps to Location:
 	FacilityType maps to type
 
 Encounter maps to Encounter:
-	Entry.FocalSubject maps to patient
+	Entry.FocalSubject maps to subject
 	OccurrenceTime  maps to period
 	EncounterType maps to class
 	// ReasonEncounterDidNotHappen

--- a/spec/shr_immunization_map.txt
+++ b/spec/shr_immunization_map.txt
@@ -8,7 +8,7 @@ Target:		FHIR_STU_3
 Immunization maps to Immunization:
 	Vaccine.Value maps to vaccineCode
 	Vaccine.VaccineManufacturer maps to manufacturer
-	ImmunizationNotGivenModifier maps to wasNotGiven
+	ImmunizationNotGivenModifier maps to notGiven
 	constrain explanation to 0..1
 	ImmunizationNotGivenModifier.Reason maps to explanation.reasonNotGiven
 	BodySite maps to site

--- a/spec/shr_lab.txt
+++ b/spec/shr_lab.txt
@@ -62,7 +62,7 @@ Description:	"A record of a request (order) for a test to be performed."
 1..1 			ActionCode is type TestCode
 0..1 			BodySite
 0..1 			TBD "Specimen" or SpecimenType
-				RequestStatus with code from http://hl7.org/fhir/ValueSet/procedure-request-status
+				RequestStatus with code from http://hl7.org/fhir/ValueSet/request-status
 
 
 // Examples of lab tests and results

--- a/spec/shr_lab_map.txt
+++ b/spec/shr_lab_map.txt
@@ -14,21 +14,21 @@ Test:
 	Interpretation maps to interpretation
 	ReferenceRange maps to referenceRange
 	ChangeFlag maps to http://hl7.org/fhir/StructureDefinition/observation-delta
-	// TestRequest maps to basedOn // In nightly build, but not in FHIR 1.8 (Jan 2017)
+	TestRequest maps to basedOn
 
 
 TestRequest maps to ProcedureRequest:
-	Entry.Author maps to orderer
+	Entry.Author maps to requester.agent
 	Entry.FocalSubject maps to subject
-	Entry.AssociatedEncounter maps to encounter
-	Reason maps to reason[x].CodeableConcept
-	OccurrenceTime maps to orderedOn   // could potentially map Entry.DateEntered to authoredOn
+	Entry.AssociatedEncounter maps to context
+	Reason maps to reasonCode
+	OccurrenceTime maps to authoredOn   // or could potentially map Entry.DateEntered to authoredOn
 	TestCode maps to code
-	// RequestNotToPerformActionModifier maps to doNotPerform // In nightly build, but not in FHIR 1.8 (Jan 2017)
+	RequestNotToPerformActionModifier maps to doNotPerform
 	RequestStatus maps to status
-	RequestedPerformanceTime maps to scheduled[x]
+	RequestedPerformanceTime maps to occurrence[x]
 	PriorityOfRequest maps to priority
-	// RequestedPerformerType maps to performerType // In nightly build, but not in FHIR 1.8 (Jan 2017)
+	RequestedPerformerType maps to performerType
 	RequestedPerformer maps to performer
 	// PerformerInstructions
 	// PatientInstructions

--- a/spec/shr_medication.txt
+++ b/spec/shr_medication.txt
@@ -173,6 +173,8 @@ Based on:		Request
 Description:	"Report of a medication prescription."
 1..1			Medication
 				RequestNotToPerformActionModifier is type MedicationNotPrescribedModifier
+				RequestStatus with code from http://hl7.org/fhir/ValueSet/medication-request-status
+				PriorityOfRequest with code from http://hl7.org/fhir/ValueSet/medication-request-priority
 0..1			Dosage
 0..1			NumberOfRepeatsAllowed
 0..1			QuantityPerDispense

--- a/spec/shr_medication_map.txt
+++ b/spec/shr_medication_map.txt
@@ -8,20 +8,20 @@ MaximumDosePerTimePeriod maps to Ratio:
 
 Medication maps to Medication:
 	Value maps to code
-	DoseForm maps to product.form
-	Ingredient maps to product.ingredient.item[x].CodeableConcept
-	Ingredient.IngredientAmount maps to product.ingredient.amount.numerator
-	Ingredient.AmountOfMedication maps to product.ingredient.amount.denominator
-	// Ingredient.IsActiveIngredient maps to ingredient.isActive // In nightly build, but not in FHIR 1.8 (Jan 2017)
+	DoseForm maps to form
+	Ingredient maps to ingredient.item[x].CodeableConcept
+	Ingredient.IngredientAmount maps to ingredient.amount.numerator
+	Ingredient.AmountOfMedication maps to ingredient.amount.denominator
+	Ingredient.IsActiveIngredient maps to ingredient.isActive
 	Brand maps to isBrand
-	// OverTheCounter maps to isOverTheCounter // In nightly build, but not in FHIR 1.8 (Jan 2017)
+	OverTheCounter maps to isOverTheCounter
 
 
 MedicationUse maps to MedicationStatement:
 	Medication maps to medication[x].Reference
 	PeriodOfUse maps to effective[x].Period
-	Reason maps to reasonForUseCodeableConcept
-	MedicationNotUsedModifier maps to notTaken
+	Reason maps to reasonCode
+	MedicationNotUsedModifier maps to taken
 	MedicationNotUsedModifier.Reason maps to reasonNotTaken
 	constrain dosage to 0..1
 	Dosage.AmountPerDose[Quantity] maps to dosage.dose[x].SimpleQuantity
@@ -29,7 +29,7 @@ MedicationUse maps to MedicationStatement:
 	Dosage.TimingOfDoses maps to dosage.timing
 	Dosage.DoseAsNeededIndicator maps to dosage.asNeeded[x].boolean
 	Dosage.DoseInstructionsText maps to dosage.text
-	Dosage.AdditionalDoseInstruction maps to dosage.additionalInstructions
+	Dosage.AdditionalDoseInstruction maps to dosage.additionalInstruction
 	Dosage.RouteIntoBody maps to dosage.route
 	Dosage.AdministrationMethod maps to dosage.method
 	Dosage.AdministrationBodySite maps to dosage.site
@@ -40,7 +40,7 @@ MedicationPrescription maps to MedicationRequest:
 	Reason maps to reasonCode
 	RequestStatus maps to status
 	RequestedPerformanceTime maps to dispenseRequest.validityPeriod
-	// PriorityOfRequest maps to priority // In nightly build, but not in FHIR 1.8 (Jan 2017)
+	PriorityOfRequest maps to priority
 	RequestedPerformer[Organization] maps to dispenseRequest.performer
 	constrain note to 0..1
 	PerformerInstructions maps to note.text
@@ -53,7 +53,7 @@ MedicationPrescription maps to MedicationRequest:
 	Dosage.TimingOfDoses maps to dosageInstruction.timing
 	Dosage.DoseAsNeededIndicator maps to dosageInstruction.asNeeded[x].boolean
 	Dosage.DoseInstructionsText maps to dosageInstruction.text
-	Dosage.AdditionalDoseInstruction maps to dosageInstruction.additionalInstructions
+	Dosage.AdditionalDoseInstruction maps to dosageInstruction.additionalInstruction
 	Dosage.RouteIntoBody maps to dosageInstruction.route
 	Dosage.AdministrationMethod maps to dosageInstruction.method
 	Dosage.AdministrationBodySite maps to dosageInstruction.site

--- a/spec/shr_observation_map.txt
+++ b/spec/shr_observation_map.txt
@@ -4,7 +4,7 @@ Target:		FHIR_STU_3
 
 Panel maps to DiagnosticReport:
 	Entry.FocalSubject maps to subject
-	Entry.AssociatedEncounter maps to encounter
+	Entry.AssociatedEncounter maps to context
 	Entry.OriginalCreationDate maps to issued
 	Value maps to codedDiagnosis
 	Observation maps to result
@@ -14,7 +14,7 @@ Panel maps to DiagnosticReport:
 
 Observation maps to Observation:
 	Entry.FocalSubject maps to subject
-	Entry.AssociatedEncounter maps to encounter
+	Entry.AssociatedEncounter maps to context
 	Entry.OriginalCreationDate maps to issued
 	ObservationCode maps to code
 	ObservationCategory maps to category

--- a/spec/shr_procedure.txt
+++ b/spec/shr_procedure.txt
@@ -25,4 +25,4 @@ Value:			CodeableConcept
 		Element:		ProcedureStatus
 		Concept:		TBD
 		Description:	"A code specifying the state of the procedure. Generally this will be in-progress or completed state."
-		Value:			code from http://hl7.org/fhir/ValueSet/procedure-status
+		Value:			code from http://hl7.org/fhir/ValueSet/event-status

--- a/spec/shr_procedure_map.txt
+++ b/spec/shr_procedure_map.txt
@@ -4,8 +4,8 @@ Target:		FHIR_STU_3
 
 Procedure maps to Procedure:
 	ProcedureStatus maps to status
-	NonOccurrenceModifier maps to notPerformed
-	NonOccurrenceModifier.Reason maps to reasonNotPerformed
+	NonOccurrenceModifier maps to notDone
+	NonOccurrenceModifier.Reason maps to notDoneReason
 	OccurrenceTime.dateTime maps to performed[x].dateTime
 	OccurrenceTime.TimePeriod maps to performed[x].Period
 	ProcedureParticipant maps to performer


### PR DESCRIPTION
Updates the definitions based on changes from FHIR 1.8.0 to FHIR 3.0.0.  This mainly deals with renamed FHIR properties and value sets.  More updates to come (to resolve mapping incompatibilities).