### PR TITLE
Fix Mis-Alignment w/ FHIR Extensible Bindings

### DIFF
--- a/spec/shr_actor.txt
+++ b/spec/shr_actor.txt
@@ -163,7 +163,7 @@ Description:	"A person or organization responsible for providing a service to th
 	Element:		HealthcareRole
 	Concept:		TBD
 	Description:	"A type of service provided to the subject."
-	Value:			CodeableConcept from HealthcareRoleVS or CodeableConcept from http://hl7.org/fhir/ValueSet/c80-practice-codes
+	Value:			CodeableConcept from HealthcareRoleVS /* or CodeableConcept from http://hl7.org/fhir/ValueSet/c80-practice-codes */
 
 	Element:		Provider
 	Concept:		MTH#C1138603

--- a/spec/shr_encounter.txt
+++ b/spec/shr_encounter.txt
@@ -73,7 +73,7 @@ Description:	"A statement about a planned or actual interaction between a patien
 	Element:		EncounterType
 	Concept:		TBD
 	Description:	"The mode of interaction, whether inpatient, outpatient, or telecare."
-	Value:			Coding from EncounterTypeVS
+	Value:			Coding from http://hl7.org/fhir/ValueSet/v3-ActEncounterCode
 
 	Element:		EncounterNonOccurrenceModifier
 	Concept:		TBD

--- a/spec/shr_encounter_vs.txt
+++ b/spec/shr_encounter_vs.txt
@@ -18,13 +18,16 @@ ValueSet:		EncounterUrgencyVS
 SCT#4525004 	"Emergency, Crisis, or Urgent Care"
 SCT#14736009	"Routine care"
 
-ValueSet:		EncounterTypeVS
-#inpatient		"In-facility or hospital setting encounter"
-#ambulatory		"Ambulatory encounter in office or facility setting"
-#home_visit		"Encounter in patient's home or location of residence"
-#tele_video		"Non-face to face contact via synchronous audio and video connection"
-#tele_audio		"Non-face to face contact via telephone or audio-only connection"
-#tele_asynch	"Non-face to face contact via text messaging or similar non-simultaneous mode"
+// Currently unused as it violates FHIR's extensible binding on Encounter.class.  Ideally
+// we would extend the FHIR VS and add the tele_* codes as level 2 codes under 'VR', but
+// apparently this is not possible
+// ValueSet:		EncounterTypeVS
+// #inpatient		"In-facility or hospital setting encounter"
+// #ambulatory		"Ambulatory encounter in office or facility setting"
+// #home_visit		"Encounter in patient's home or location of residence"
+// #tele_video		"Non-face to face contact via synchronous audio and video connection"
+// #tele_audio		"Non-face to face contact via telephone or audio-only connection"
+// #tele_asynch	"Non-face to face contact via text messaging or similar non-simultaneous mode"
 
 ValueSet:		ReferralSourceTypeVS
 #self			"Self, or personal associated, such as family or friend"

--- a/spec/shr_lab.txt
+++ b/spec/shr_lab.txt
@@ -42,7 +42,7 @@ Description:	"A laboratory, radiologic, or other clinical test or measurement us
 		Element:		Interpretation
 		Concept:		MTH#C0420833
 		Description:	"A clinical interpretation of a measurement."
-		Value:			CodeableConcept from TestInterpretationVS
+		Value:			CodeableConcept from http://hl7.org/fhir/ValueSet/observation-interpretation
 
 		Element:		ReferenceRange
 		Concept:		MTH#C0883335

--- a/spec/shr_lab_vs.txt
+++ b/spec/shr_lab_vs.txt
@@ -10,18 +10,6 @@ ValueSet:			RequestStatusVS
 #suspended			"The request has been held by originating system/user request."
 #completed			"The diagnostic testing has been completed, the report(s) released, and no further work is planned."
 
-ValueSet:			TestInterpretationVS
-MTH#C0205307		"Normal"
-MTH#C0205161		"Abnormal"
-MTH#C1548135		"Very abnormal"
-TBD#TBD				"Emergency abnormal"
-TBD#TBD				"Emergency low"
-MTH#C0442811		"Very low"
-MTH#C1611820		"Low"
-MTH#C0205250		"High"
-MTH#C0442804		"Very high"
-TBD#TBD				"Emergency high"
-
 ValueSet:			ChangeFlagVS
 Concept:			MTH#C1705241
 MTH#C2346711		"About the same"

--- a/spec/shr_observation.txt
+++ b/spec/shr_observation.txt
@@ -31,7 +31,7 @@ Description:	"An act that is intended to result in new information about a subje
 		Element:		ObservationCategory
 		Concept:		TBD
 		Description:	"A categorization of the observation according to how the observation was collected or its clinical area."
-		Value:			CodeableConcept from http://hl7.org/fhir/ValueSet/observation-category or CodeableConcept
+		Value:			CodeableConcept from http://hl7.org/fhir/ValueSet/observation-category /* or CodeableConcept */
 
 		Element:		ObservationReason
 		Concept:		TBD
@@ -109,12 +109,12 @@ Description:	"A group of related observations, usually (but not always) taken to
 		Concept:		TBD
 		Description:	"A code that classifies the clinical discipline, department or diagnostic service that created the report (e.g. cardiology, biochemistry, hematology, MRI). This is used for searching, sorting and display purposes."
 		Value:			CodeableConcept
-		
+
 		Element:		ReportStatus
 		Concept:		TBD
 		Description:	"The status of the report associated with this panel."
-		Value:			code from http://hl7.org/fhir/ValueSet/diagnostic-report-status 
-		
+		Value:			code from http://hl7.org/fhir/ValueSet/diagnostic-report-status
+
 
 Element:		HistoryObservation
 Concept:		MTH#C2004062 "History of previous events"


### PR DESCRIPTION
Several fixes relates to overriding extensible bindings in FHIR and/or trying to support two value sets bindings (FHIR only allows one at a time).