### PR TITLE
Changes for SHR JSON Schema

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "projectShorthand": "EXAMPLE",
     "projectURL": "http://example.com",
     "fhirURL": "http://example.com/fhir",
+    "entryTypeURL": "http://example.com/spec",
     "igIndexContent": "exampleIndexContent.html",
     "publisher": "Example Publisher",
     "contact": [

--- a/spec/config.json
+++ b/spec/config.json
@@ -3,6 +3,7 @@
     "projectShorthand": "SHR",
     "projectURL": "http://standardhealthrecord.org",
     "fhirURL": "http://standardhealthrecord.org/fhir",
+    "entryTypeURL": "http://standardhealthrecord.org/spec/",
     "igIndexContent": "shrIndexContent.html",
     "publisher": "The MITRE Corporation: Standard Health Record Collaborative",
     "contact": [

--- a/spec/shr_base.txt
+++ b/spec/shr_base.txt
@@ -16,7 +16,7 @@ Description:	"Metadata attributes that apply to any item represented in the stan
 1..1			EntryId
 0..1			PersonOfRecord
 0..1			Version
-1..*			EntryType
+1..1			EntryType
 1..1    		CreationTime
 1..1			LastUpdated
 0..1			Narrative
@@ -41,7 +41,7 @@ Description:	"Metadata attributes that apply to any item represented in the stan
 	
 	Element:		EntryType  // Would EntryClass be clearer?
 	Concept:		TBD
-	Description:	"SHR data element identifier, as a URI. The EntryType array includes the entire 'based on' hierarchy to enable searching for classes of things, for example, searching for all vital signs, or all types of behavioral observations."
+	Description:	"SHR data element identifier, as a URI."
 	Value:			uri
 
 	Element: 		LastUpdated

--- a/spec/shr_core.txt
+++ b/spec/shr_core.txt
@@ -639,8 +639,8 @@ Element:		Frequency   // TODO: should be a ratio, but the problem is that ratio 
 Based on:		Ratio
 Concept:		MTH#C0376249
 Description:	"How many occurrences of an event per unit of time."
-1..1			Numerator with units UCUM#1
-1..1			Denominator.Units with Coding from http://hl7.org/fhir/ValueSet/units-of-time
+1..1			Numerator.Quantity with units UCUM#1
+1..1			Denominator.Quantity.Units with Coding from http://hl7.org/fhir/ValueSet/units-of-time
 
 Element:		SemiquantFrequency
 Concept:		TBD


### PR DESCRIPTION
A few changes @jgibson made during implementation/testing of JSON Schema Exporter.

1. Added new config for the prefix for entry type URLs
2. Changed `Entry.EntryType` cardinality from `1..*` to `1..1`
3. Fixed incorrect paths in `Ratio` constraints

In regard to 2, this was discussed in an email thread.  The consensus was that only the most specific type needs to be listed.  Anyone w/ access to the spec could easily get the type hierarchy if really necessary.  In the JSON representation, this change made the JSON much more compact.

@markkramerus -- please review and confirm you are ok with the changes.