### PR TITLE
Flux-related Changes

### DIFF
--- a/config.json
+++ b/config.json
@@ -3,6 +3,7 @@
     "projectShorthand": "EXAMPLE",
     "projectURL": "http://example.com",
     "fhirURL": "http://example.com/fhir",
+    "entryTypeURL": "http://example.com/spec",
     "igIndexContent": "exampleIndexContent.html",
     "publisher": "Example Publisher",
     "contact": [

--- a/spec/config.json
+++ b/spec/config.json
@@ -3,6 +3,7 @@
     "projectShorthand": "SHR",
     "projectURL": "http://standardhealthrecord.org",
     "fhirURL": "http://standardhealthrecord.org/fhir",
+    "entryTypeURL": "http://standardhealthrecord.org/spec/",
     "igIndexContent": "shrIndexContent.html",
     "publisher": "The MITRE Corporation: Standard Health Record Collaborative",
     "contact": [

--- a/spec/shr_base.txt
+++ b/spec/shr_base.txt
@@ -16,7 +16,7 @@ Description:	"Metadata attributes that apply to any item represented in the stan
 1..1			EntryId
 0..1			PersonOfRecord
 0..1			Version
-1..*			EntryType
+1..1			EntryType
 1..1    		CreationTime
 1..1			LastUpdated
 0..1			Narrative
@@ -41,7 +41,7 @@ Description:	"Metadata attributes that apply to any item represented in the stan
 	
 	Element:		EntryType  // Would EntryClass be clearer?
 	Concept:		TBD
-	Description:	"SHR data element identifier, as a URI. The EntryType array includes the entire 'based on' hierarchy to enable searching for classes of things, for example, searching for all vital signs, or all types of behavioral observations."
+	Description:	"SHR data element identifier, as a URI."
 	Value:			uri
 
 	Element: 		LastUpdated

--- a/spec/shr_behavior.txt
+++ b/spec/shr_behavior.txt
@@ -47,13 +47,13 @@ includes 0..*	ExposureAmount
 		Based on:		ObservationComponent
 		Concept:		MTH#C0556346
 		Description:	"A description of the frequency of substance use."
-		Value:			CodeableConcept could be from SemiquantitativeFrequencyVS	
+		Value:			CodeableConcept could be from SemiquantitativeFrequencyVS
 
 EntryElement:   IntravenousDrugUse
 Based on:       SubstanceUse
 Concept:        MTH#C0242566
 Description:    "Records whether the subject injects recreational drugs."
-1..1            ObservationComponent.RouteIntoBody is MTH#C1522726 "Intravenous route"
+1..1            ObservationComponent.ExposureRoute is MTH#C1522726 "Intravenous route"
 1..1            ObservationComponent.ExposureMethod is MTH#C0021494 "Intravenous Injection"
 
 EntryElement:	NicotineUse
@@ -61,7 +61,7 @@ Based on:		SubstanceUse
 Concept:		LNC#11367-0
 Description:	"The subject's current or past use of nicotine."
 				Value is MTH#C2363943 "Nicotine"
-//1..1            ObservationComponent.RouteIntoBody from TBD "NicotineRouteVS"  
+//1..1            ObservationComponent.ExposureRoute from TBD "NicotineRouteVS"
 //1..1            ObservationComponent.ExposureMethod from TBD "NicotineExposureMethodVS"  e.g. first hand, second hand, smoked, vaped, chewed
 
 
@@ -90,13 +90,13 @@ includes 0..1	AlcoholBingeFrequency
 	Description:	"How often have you had 6 or more Units if female, or 8 or more if male, on a single occasion in the last year?."
 	Value:			CodeableConcept from SemiquantitativeFrequencyVS
 
-				
+
 EntryElement:	SubstanceAbuseTreatment
 Concept: 		TBD
 Based on:		ProcedurePerformed
 Description:	"The treatment program used to address a substance abuse problem."
 				Type from SubstanceAbuseTreatmentTypeVS
-	
+
 
 EntryElement:	Religion
 Concept:		LNC#81364-2
@@ -126,7 +126,7 @@ Description:	"A group of place of religious practice."
 Value:			string
 				Category includes #religion
 
-				
+
 EntryElement:	DietFollowed
 Concept:		TBD
 Based on:		QuestionAnswer
@@ -174,7 +174,7 @@ Concept:		TBD
 Description:	"How often the subject has trouble falling asleep."
 Value:			CodeableConcept from QualitativeFrequencyVS
 				Category includes #sleep
-	
+
 EntryElement:	TroubleStayingAsleep
 Based on:		QuestionAnswer
 Concept:		TBD
@@ -196,7 +196,7 @@ Description:	"Typical hours spent sleeping per night."
 Value:			IntegerQuantity
 				Category includes #sleep
 
-				
+
 EntryElement:	PhysicalActivityPanel
 Based on:		Observation
 Concept:		TBD
@@ -207,28 +207,28 @@ Description:	"Questions related to physical activity."
 includes 0..1	PhysicalActivityLevel
 includes 0..1	ExerciseHoursPerWeek
 includes 0..*	PhysicalActivityLimitation
-	
-				
+
+
 EntryElement:	PhysicalActivityLevel
 Based on:		QuestionAnswer
 Concept:		LNC#28323-4
 Description:	"The amount of exercise or other physical activity compared to others of the same age.  See BMC Medical Research Methodology 2012 12:20 1471-2288."
 Value:			CodeableConcept from QualitativeValueScaleVS
-				Category includes #exercise 
+				Category includes #exercise
 
 EntryElement:	ExerciseHoursPerWeek
 Concept:		TBD
 Based on:		BehavioralFinding
 Description:	"Hours of moderate or vigorous activity per week."
 Value:			IntegerQuantity  // TODO: potentially change to ratio with Units hours per one week
-				Category includes #exercise 
+				Category includes #exercise
 
 EntryElement:	PhysicalActivityLimitation
 Concept:		TBD
 Based on:		QuestionAnswer
 Description:	"Anything that limits physical activity, including health factors, logistical, monetary, or social restrictions."
 Value:			CodeableConcept from PhysicalActivityLimitationVS
-				Category includes #exercise 
+				Category includes #exercise
 
 
 

--- a/spec/shr_core.txt
+++ b/spec/shr_core.txt
@@ -639,8 +639,8 @@ Element:		Frequency   // TODO: should be a ratio, but the problem is that ratio 
 Based on:		Ratio
 Concept:		MTH#C0376249
 Description:	"How many occurrences of an event per unit of time."
-1..1			Numerator with units UCUM#1
-1..1			Denominator.Units with Coding from http://hl7.org/fhir/ValueSet/units-of-time
+1..1			Numerator.Quantity with units UCUM#1
+1..1			Denominator.Quantity.Units with Coding from http://hl7.org/fhir/ValueSet/units-of-time
 
 Element:		SemiquantFrequency
 Concept:		TBD

--- a/spec/shr_core.txt
+++ b/spec/shr_core.txt
@@ -9,7 +9,7 @@ CodeSystem:     LNC = http://loinc.org
 CodeSystem:     SCT = http://snomed.info/sct
 CodeSystem:     MTH = http://ncimeta.nci.nih.gov
 CodeSystem:		NCI = https://evs.nci.nih.gov/ftp1/CDISC/SDTM/
-CodeSystem:     UCUM = http://unitsofmeasure.org 
+CodeSystem:     UCUM = http://unitsofmeasure.org
 
 
 //------------ Complex Types aligned with FHIR ---------------
@@ -55,7 +55,7 @@ Based on:		Quantity
 Concept:		MTH#C0012751
 Description:	"The measure of space separating two objects or points."
 				Units with Coding from UnitsOfLengthVS
-				
+
 Element:		Duration
 Based on:		Quantity
 Concept:		MTH#C0449238
@@ -108,8 +108,8 @@ Description:	"A file that contains audio, video, image, or similar content."
 	Concept:		TBD
 	Description:	"A hash code of the data (sha-1, base64ed)"
 	Value:			base64Binary
-	
-	Element:   	 	CreationTime  
+
+	Element:   	 	CreationTime
 	Concept:        MTH#C3669169
 	Description:    "The point in time when the information was recorded in the system of record."
 	Value:          dateTime  // we can map to instant from dateTime
@@ -125,9 +125,9 @@ Value:			0..1 code
 0..1 			CodeSystemVersion
 0..1			DisplayText
 //0..*			CodingQualifier
-	
+
 /*
- TODO: Suggest changing FHIR's Coding.userSelected to Coding.qualifier 
+ TODO: Suggest changing FHIR's Coding.userSelected to Coding.qualifier
 	Element:		CodingQualifier
 	Concept:		TBD
 	Description:	"A description of the purpose or origin of the code that assists in understanding the code."
@@ -143,7 +143,7 @@ Value:			0..1 code
 	Concept:		TBD
 	Description:	"The version of the vocabulary being used, if applicable."
 	Value:			string // Should be id type in FHIR, but it is a string (no issue recorded yet)
-	
+
 Element:		CodeableConcept
 Concept:		TBD
 Description:	"A set of codes drawn from different coding systems, representing the same concept."
@@ -170,12 +170,12 @@ Description:	"An interval defined by a quantitative upper and/or lower bound. On
 	Element:		LowerBound
 	Concept:		TBD
 	Description:	"The lower limit on a range"
-	Value:			Quantity  // or decimal or unsignedInt or integer 
+	Value:			Quantity  // or decimal or unsignedInt or integer
 
 	Element:		UpperBound
 	Concept:		TBD
 	Description:	"The upper limit on a quantitative value."
-	Value:			Quantity  // or decimal or unsignedInt or integer 
+	Value:			Quantity  // or decimal or unsignedInt or integer
 
 Element:		Ratio
 Concept:		MTH#C0456603
@@ -195,7 +195,7 @@ Description:	"A unit of measurement for the quotient of the amount of one entity
 
 Element:   		ContactPoint
 Concept:		MTH#C2986441
-Description:	"An electronic means of contacting an organization or individual."		
+Description:	"An electronic means of contacting an organization or individual."
 1..1			TelecomNumberOrAddress
 1..1			Type from http://hl7.org/fhir/ValueSet/contact-point-system
 0..1			Purpose from http://hl7.org/fhir/ValueSet/contact-point-use
@@ -205,7 +205,7 @@ Description:	"An electronic means of contacting an organization or individual."
 	Element:		TelecomNumberOrAddress
 	Concept:		TBD
 	Description:	"A user name or other identifier on a telecommunication network, such as a telephone number (including country code and extension, if necessary), email address, or SkypeID."
-	Value:			string	
+	Value:			string
 
 Element:		ContactDetail
 Concept:		TBD
@@ -253,11 +253,11 @@ Description: "A timing schedule that specifies an event that may occur multiple 
 	Concept:		TBD
 	Description: 	"A code for the timing schedule. Some codes such as BID are ubiquitous, but many institutions define their own additional codes. If a code is provided, the code is understood to be a complete statement of whatever is specified in the structured timing data, and either the code or the data may be used to interpret the Timing, with the exception that .repeat.bounds still applies over the code (and is not contained in the code)."
 	Value:			CodeableConcept from http://hl7.org/fhir/ValueSet/timing-abbreviation if covered
-	
+
 	Element:		EventDuration
 	Description:	"The length of the recurring event."
 	Value:			DurationRange
-	
+
 	Element:	RecurrencePattern
 	Concept:	TBD
 	Description: "A set of rules that describe when a recurring event is scheduled."
@@ -272,17 +272,17 @@ Description: "A timing schedule that specifies an event that may occur multiple 
 		Concept:		TBD
 		Description:	"The period of time after which the pattern repeats, for example, each day. To specify an event should take place every other Monday, the recurrence interval should be two weeks, and DayOfWeek should be Monday."
 		Value:			Duration
-		
+
 		Element:		DayOfWeek
 		Concept:		TBD
 		Description:	"A day of the week that the pattern should take place."
 		Value:			code from http://hl7.org/fhir/ValueSet/days-of-week
-		
+
 		Element:		TimeOfDay
 		Concept:		TBD
 		Description:	"Time of day the event should take place on the designated day(s). TimeOfDay should only be specified if the RecurrenceInterval and/or DayOfWeek establishes the day when the event should take place."
 		Value:			time
-		
+
 		Element:		DailyLifeEvent
 		Concept:		TBD
 		Description:	"A quotidian landmark, such as rising, mealtime, or bedtime, when an event should take place."
@@ -292,26 +292,26 @@ Description: "A timing schedule that specifies an event that may occur multiple 
 		Concept:		TBD
 		Description:	"A time in minutes before or after a given life event, for example, 30 minutes before a meal. Whether this means before or after is carried by the life event code."
 		Value:			unsignedInt
-		
+
 		Element:		CountPerInterval
 		Concept:		TBD
 		Description:	"How many times the event should take place during one recurrence interval, for example, to specify 3-4 times per day, the CountPerInterval should be 3 to 4."
 		0..1			MinCount
 		0..1			MaxCount
-		
+
 				Element:	MinCount
 				Description: "Lower bound on a count."
-				Value:		integer   // FHIR - should be unsignedInt	
-				
+				Value:		integer   // FHIR - should be unsignedInt
+
 				Element:	MaxCount
 				Description: "Upper bound on a count."
-				Value:		integer // FHIR - should be unsignedInt		
-		
+				Value:		integer // FHIR - should be unsignedInt
+
 	Element: 		RecurrenceRange
 	Concept:		TBD
 	Description:	"The start and end of the overall recurrence pattern in terms of dates/times or in terms of number of repeats. Could also be an event, such as when all doses are taken."
 	Value:			TimePeriod or NumberOfRepeats
-			
+
 		Element:		NumberOfRepeats
 		Concept:		TBD
 		Description:	"How many times the action should be repeated."
@@ -328,7 +328,7 @@ Description: "A digital Signature - XML DigSig, JWT, Graphical image of signatur
 0..1		ContentType
 0..1		BinaryData
 
-	Element:   	 	TypeAsaCoding 
+	Element:   	 	TypeAsaCoding
 	Concept:        MTH#C0332307
 	Description:    ""
 	Value:          Coding
@@ -358,32 +358,32 @@ Value:		string
 	Element:	Origin
 	Description:	"The base quantity that a measured value of zero represents. In addition, this provides the units of the entire measurement series."
 	Value:		SimpleQuantity
-	
+
 	Element:	MillisecondsBetweenSamples
 	Description: "The length of time between sampling times, measured in milliseconds."
 	Value:		decimal
-	
+
 	Element:	CorrectionFactor
 	Description: "A correction factor that is applied to the sampled data points before they are added to the origin."
 	Value:		decimal
-	
-	Element:	LowerLimit	
+
+	Element:	LowerLimit
 	Concept:	TBD
 	Description:	"The lower limit of detection of the measured points. This is needed if any of the data points have the value 'L' (lower than detection limit)."
 	Value:		decimal
-	
+
 	Element:		UpperLimit
 	Concept:		TBD
 	Description:	"The upper limit of detection of the measured points. This is needed if any of the data points have the value 'U' (higher than detection limit)."
 	Value:			decimal
-	 
+
 	Element:	Dimensions
 	Concept:	TBD
 	Description:	"The number of sample points at each time point. If this value is greater than one, then the dimensions will be interlaced - all the sample points for a point in time will be recorded at once."
 	Value:		positiveInt
-	
-	
-		
+
+
+
 
 Element:   		Address
 Concept:		MTH#C0682130
@@ -433,7 +433,7 @@ Description:    "An address expressed using postal conventions (as opposed to GP
 	Description:    "Country - a nation as commonly understood or generally accepted, expressed in ISO 3166 Alpha-2 (2-letter) codes."
 	Value:         	string
 
-	
+
 //------------ Complex Data Types not in FHIR ----------------
 
 Element:		Count
@@ -474,7 +474,7 @@ Element:		DurationRange
 Description:	"A range of durations."
 0..1			LowerBound value is type Duration
 0..1			UpperBound value is type Duration
-	
+
 Element:		Statistic
 Based on: 		Quantity
 Concept:		MTH#C2828391
@@ -639,8 +639,8 @@ Element:		Frequency   // TODO: should be a ratio, but the problem is that ratio 
 Based on:		Ratio
 Concept:		MTH#C0376249
 Description:	"How many occurrences of an event per unit of time."
-1..1			Numerator.Quantity with units UCUM#1
-1..1			Denominator.Quantity.Units with Coding from http://hl7.org/fhir/ValueSet/units-of-time
+            Numerator.Quantity with units UCUM#1
+            Denominator.Quantity.Units with Coding from http://hl7.org/fhir/ValueSet/units-of-time
 
 Element:		SemiquantFrequency
 Concept:		TBD
@@ -671,7 +671,7 @@ Concept:		MTH#C2985763
 Description:	"The date and time span for which something is active, valid, or in force."
 
 Element:		ReceivedTime
-Concept:		MTH#C2735124	
+Concept:		MTH#C2735124
 Description:	"Time received by accepting facility or unit."
 Value:			dateTime
 
@@ -797,7 +797,7 @@ Value:			string
 		Description:    "Part of the name that is acquired as a title due to academic, legal, employment or nobility status, etc. and that appears at the end of the name."
 		Value:          string
 
-	
+
 Element:		BodyPosition
 Concept:		MTH#C1262869
 Description:	"The position or physical attitude of the body."
@@ -825,7 +825,7 @@ Concept:		MTH#C0333052
 Description:	"A string identifying the particular of form of something (such as a code system or software product) that is different in some way from another form of the same thing."
 Value:			id
 
-Element:		OrganizationalIdentifier 
+Element:		OrganizationalIdentifier
 Concept:		TBD
 Based on:		Identifier
 Description:	"A code identifying a specific organization. The NPI should be provided, if available. Other business identifiers, such employer tax ID, or MVX code for vaccine manufacturers, should also be provided."
@@ -851,4 +851,4 @@ Value:			CodeableConcept
 Element:		Definitional
 Concept:		MTH#C1704788
 Description:	"An indicator that the item is a description of a thing, not a thing that actually exists. For example, a group of people between ages 30 and 40 with Type II diabetes can be defined, without existing as a set of particular people."
-Value:			boolean 
+Value:			boolean


### PR DESCRIPTION
These changes relate to issues that were encountered during the development of the JSON schema exporter or in support of Flux.  They represent the element definitions that were used to generate the schemas and ES6 classes that Flux is currently using.

In summary:
- Updated "example" config (inconsequential to Flux/SHR)
- Changed `Entry.EntryType` cardinality from `1..*` to `1..1`
    - JSON was extremely verbose w/ whole type hierarchy encoded, and the type hierarchy can be easily inferred from the most specific type.
- Fixed `RouteIntoBody`/`ExposureRoute` mixup in `IntravenousDrugUse` and `NicotineUse`
- Fixed incorrect paths in `Ratio`
    - `Numerator` and `Denominator` paths were missing the `Quantity` subpath in their constraints
- Trimmed lots of trailing whitespace (side-effect of editing files)

Since these changes reflect the current state of flux, it's best to merge them into master.  If other changes are necessary, they can be made in following pull-requests.