### PR TITLE
Removed a sentence that was accidentally in the wrong code description.

### DIFF
--- a/spec/oncology_vs.txt
+++ b/spec/oncology_vs.txt
@@ -199,7 +199,7 @@ Description:	"Intepretation of OncotypeDX DCIS (Ductal Carcinoma In Situ) Recurr
 ValueSet:		MammaprintRiskScoreInterpretationVS
 Description:	"Intepretation of Mammaprint Recurrence Score"
 #low_risk		"Score between 0.0 and +1.0, meaning a patient has on average a 10% chance that her cancer will recur within 10 years without any additional adjuvant treatment, either hormonal therapy or chemotherapy."
-#high_risk		"Score between -1.0 and 0.0, meaning a patient has a 29% chance that her cancer will recur within 10 years without any additional adjuvant treatment, either hormonal therapy or chemotherapy.Recurrence Score greater than or equal to 55: The cancer has a high risk of recurrence, and the benefits of chemotherapy are likely to be greater than the risks of side effects."
+#high_risk		"Score between -1.0 and 0.0, meaning a patient has a 29% chance that her cancer will recur within 10 years without any additional adjuvant treatment, either hormonal therapy or chemotherapy."
 
 
 ValueSet:			RecurrenceRiskScoreInterpretationVS


### PR DESCRIPTION
The sentence that was removed is actually from the `#high_risk` code in `OncotypeDxDCISRiskScoreInterpretationVS`, which is right above the affected Valueset.