### PR TITLE
Remove color from error output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ before_install:
 script:
   - node . ../spec/ > run.log
   - cat run.log
-  - errors=$(grep "errors" run.log)
+  - errors=$(grep "errors" run.log | sed $'s,\x1b\\[[0-9;]*[a-zA-Z],,g')
   - if [[ "$errors" != "0 errors" ]]; then ( echo There were errors in running shr-cli. ; exit 1 ); fi


### PR DESCRIPTION
It turns out that bash string comparison cares about string color. This puts up a fix to the `.travis.yml` to strip the string color from the `grep` output.