### PR TITLE
Updates to BC and ODH configs

### DIFF
--- a/spec/ig-breast-config.json
+++ b/spec/ig-breast-config.json
@@ -1,12 +1,12 @@
 {
-    "projectName": "HL7 FHIR Implementation Guide: Breast Cancer Data, Release 2 - US Realm (Draft for Comment)",
+    "projectName": "HL7 FHIR Implementation Guide: Breast Cancer Data, Release 1 - US Realm (Draft for Comment 2)",
     "projectShorthand": "BC",
     "projectURL": "http://hl7.org/fhir/us/breastcancer/",
     "fhirURL": "http://hl7.org/fhir/us/breastcancer/",
     "entryTypeURL": "http://hl7.org/fhir/us/breastcancer/spec/",
     "implementationGuide":
 	{
-        "npmName": "us-breastcancer",
+        "npmName": "hl7.fhir.us.breastcancer",
         "version": "0.2.0",
 		"includeLogicalModels": true,
 		"includeModelDoc": true,

--- a/spec/ig-odh-config.json
+++ b/spec/ig-odh-config.json
@@ -1,13 +1,13 @@
 {
-    "projectName": "Standard Health Record",
-    "projectShorthand": "SHR",
-    "projectURL": "http://standardhealthrecord.org",
-    "fhirURL": "http://standardhealthrecord.org/fhir",
-    "entryTypeURL": "http://standardhealthrecord.org/spec/",
+    "projectName": "HL7 FHIR Profile: Occupational Data for Health (ODH), Release 1 (Standard for Trial Use)",
+    "projectShorthand": "ODH",
+    "projectURL": "http://hl7.org/fhir/us/odh",
+    "fhirURL": "http://hl7.org/fhir/us/odh",
+    "entryTypeURL": "http://hl7.org/fhir/us/odh/spec",
     "implementationGuide":
 	{
-        "npmName": "ig-odh",
-        "version": "0.1.0",
+        "npmName": "hl7.fhir.us.odh",
+        "version": "1.0.0",
 		"includeLogicalModels": true,
 		"includeModelDoc": false,
 		"indexContent": "LandingPageOccupation.html",


### PR DESCRIPTION
Breast Cancer config changes:
- Change "Release 2" to "Release 1" to match ballot desktop
- Change "Draft for Comment" to "Draft for Comment 2"
- Change NPM name to "hl7.fhir.us.breastcancer" per Grahame's request

Occupational Data for Health:
- Change project name to match Ballot Desktop name
- Change shorthand to ODH
- Change URLs to canonical forms assigned by HL7
- Change NPM name to "hl7.fhir.us.odh" per HL7
- Change version to 1.0.0