### PR TITLE
Updates to ODH and BC configs

### DIFF
--- a/spec/ig-breast-config.json
+++ b/spec/ig-breast-config.json
@@ -1,32 +1,37 @@
 {
-    "projectName": "Standard Health Record",
-    "projectShorthand": "SHR",
-    "projectURL": "http://standardhealthrecord.org",
-    "fhirURL": "http://standardhealthrecord.org/fhir",
-    "entryTypeURL": "http://standardhealthrecord.org/spec/",
-    "implementationGuide": 
+    "projectName": "HL7 FHIR Implementation Guide: Breast Cancer Data, Release 1 - US Realm (Draft for Comment 2)",
+    "projectShorthand": "BC",
+    "projectURL": "http://hl7.org/fhir/us/breastcancer/",
+    "fhirURL": "http://hl7.org/fhir/us/breastcancer/",
+    "entryTypeURL": "http://hl7.org/fhir/us/breastcancer/spec/",
+    "implementationGuide":
 	{
+        "npmName": "hl7.fhir.us.breastcancer",
+        "version": "0.2.0",
 		"includeLogicalModels": true,
 		"includeModelDoc": true,
-		"indexContent": "LandingPageBreastCancer.html",
-		"primarySelectionStrategy": 
+        "indexContent": "LandingPageBreastCancer.html",
+        "historyLink": "http://hl7.org/fhir/us/breastcancer/history.html",
+		"primarySelectionStrategy":
 		{
-			"strategy": "entry"
+            "strategy": "namespace",
+            "primary": ["shr.oncology"],
+            "hideSupporting": true
 		}
-	},	
+	},
 	"filterStrategy":
 	{
         "filter": true,
 		"strategy": "namespace",
 		"target": ["shr.oncology"]
 	},
-    "publisher": "The MITRE Corporation: Standard Health Record Collaborative",
+    "publisher": "The HL7 Cancer Interoperability Group sponsored by Clinical Interoperability Council Work Group (CIC)",
     "contact": [
         {
             "telecom": [
                 {
                     "system": "url",
-                    "value": "http://standardhealthrecord.org"
+                    "value": "http://www.hl7.org/Special/committees/cic/index.cfm"
                 }
             ]
         }

--- a/spec/ig-odh-config.json
+++ b/spec/ig-odh-config.json
@@ -1,20 +1,22 @@
 {
-    "projectName": "Standard Health Record",
-    "projectShorthand": "SHR",
-    "projectURL": "http://standardhealthrecord.org",
-    "fhirURL": "http://standardhealthrecord.org/fhir",
-    "entryTypeURL": "http://standardhealthrecord.org/spec/",
-    "implementationGuide": 
+    "projectName": "HL7 FHIR Profile: Occupational Data for Health (ODH), Release 1 (Standard for Trial Use)",
+    "projectShorthand": "ODH",
+    "projectURL": "http://hl7.org/fhir/us/odh",
+    "fhirURL": "http://hl7.org/fhir/us/odh",
+    "entryTypeURL": "http://hl7.org/fhir/us/odh/spec",
+    "implementationGuide":
 	{
+        "npmName": "hl7.fhir.us.odh",
+        "version": "1.0.0",
 		"includeLogicalModels": true,
 		"includeModelDoc": false,
 		"indexContent": "LandingPageOccupation.html",
-		"primarySelectionStrategy": 
+		"primarySelectionStrategy":
 		{
             "strategy": "namespace",
             "primary": ["shr.occupation"]
 		}
-	},	
+	},
 	"filterStrategy":
 	{
         "filter": true,

--- a/spec/ig-odh-config.json
+++ b/spec/ig-odh-config.json
@@ -14,7 +14,8 @@
 		"primarySelectionStrategy":
 		{
             "strategy": "namespace",
-            "primary": ["shr.occupation"]
+            "primary": ["shr.occupation"],
+            "hideSupporting": true
 		}
 	},
 	"filterStrategy":


### PR DESCRIPTION
Occupational Data for Health:
- Change project name to match Ballot Desktop name
- Change shorthand to ODH
- Change URLs to canonical forms assigned by HL7
- Added NPM name
- Added version

Breast Cancer config changes:
- Change "Release 2" to "Release 1" to match ballot desktop
- Change "Draft for Comment" to "Draft for Comment 2"
- Change NPM name to "hl7.fhir.us.breastcancer" per Grahame's request
- Changed filter strategy to filter on shr.oncology namespace
- Changed publisher info to indicate CIIC