### PR TITLE
Authoring fix for Issue #73 (Ki67 needs to support reference range)

### DIFF
--- a/spec/shr_oncology.txt
+++ b/spec/shr_oncology.txt
@@ -617,6 +617,7 @@ includes 0..1	Ki-67NuclearAntigenValue  // separated to its own element since th
 	Concept:		LNC#29593-1 "Cells.Ki-67 nuclear Ag/​100 cells in Tissue by Immune stain"
 	Description:	"Ki-67 is a protein phosphatase whose expression is strongly associated with cell proliferation and encoded by the MKI67 gene.  The Ki-67 antigen is measured quantitatively as a percentage."
 	Value:		 	Quantity with units UCUM#%
+	0..1			ReferenceRange
 
 
 /*


### PR DESCRIPTION
https://github.com/standardhealth/shr_spec/issues/73

This fix shows in the logical model but remains as 0..0 in the resulting FHIR profile.  Need  @markkramerus or @cmoesel to further investigate if this is a tooling bug or a limitation in FHIR that needs a different class to represent this.