### PR TITLE
Update oncocore config to have no logical models or history link

### DIFF
--- a/spec/ig-oncocore-config.json
+++ b/spec/ig-oncocore-config.json
@@ -9,10 +9,9 @@
 	{
         "npmName": "oncocore",
         "version": "0.2.0",
-		"includeLogicalModels": true,
+		"includeLogicalModels": false,
 		"includeModelDoc": true,
         "indexContent": "IndexFolder_Oncocore",
-        "historyLink": "http://hl7.org/fhir/us/oncocore/history.html",
 		"primarySelectionStrategy":
 		{
             "strategy": "hybrid",


### PR DESCRIPTION
Since DSTU2 export doesn't support logical models yet, it doesn't make
sense to put a link in the IG.  And since there is no history for this
IG yet, a history link doesn't make sense either. Remove both via config.