### PR TITLE
Revert Entry

### DIFF
--- a/spec/ig-oncocore-config.json
+++ b/spec/ig-oncocore-config.json
@@ -23,7 +23,7 @@
 	{
         "filter": true,
 		"strategy": "hybrid",
-		"target": ["oncocore"]
+		"target": ["oncocore", "shr.base.Entry"]
 	},
     "publisher": "The HL7 Cancer Interoperability Group sponsored by Clinical Interoperability Council Work Group (CIC)",
     "contact": [

--- a/spec/shr_base.txt
+++ b/spec/shr_base.txt
@@ -9,30 +9,37 @@ CodeSystem:     SCT = http://snomed.info/sct
 CodeSystem:		NCI = https://evs.nci.nih.gov/ftp1/CDISC/SDTM/
 CodeSystem:		OBSCAT = http://hl7.org/fhir/observation-category
 
+// NOTE: Entry will eventually be deprecated, as its fields are really a part
+// of the implementation, NOT a part of the model. Once the CIMPL tooling
+// makes these implicit, Entry and its field elements can go away.
 Element: 		Entry
 Concept:		MTH#C1705654
 Description:	"Obsolete. Use InformationItem"
+0..1			ShrId
+0..1			EntryId
+0..1			EntryType
 
-/*0..1			ShrId
-
-	Element:		ShrId
-	Concept:		TBD
+	Element:			ShrId
+	Concept:			TBD
 	Description:	"A unique, persistent, permanent identifier for the overall health record belonging to the Patient."
-	Value:			id */
+	Value:				id
 	
+	Element:    	EntryId
+	Concept:      MTH#C0600091
+	Description:  "A persistent, permanent identifier for an entry in a health record, unique within the scope of the health record."
+	Value:        id
+
+	Element:			EntryType  // Would EntryClass be clearer?
+	Concept:			TBD
+	Description:	"The class of the item, as a URI."
+	Value:				uri
 
 Abstract Element: InformationItem
 Concept:		MTH#C1705654
 Description:	"Parent class for any item in clinical or administrative health-related system. Contains metadata attributes that apply to any item represented in the standard health record. An InformationItem can belong to a single person's health record, or represent an entity that surfaces in multiple records, such as organizations, providers, payments, decision support artifacts, etc."
-0..1			EntryId
 0..1			Narrative
 0..1			Language
 0..1			Metadata
-
-	Element:    	EntryId
-	Concept:        MTH#C0600091
-	Description:    "A persistent, permanent identifier for an entry in a health record, unique within the scope of the health record."
-	Value:          id
 
 	Element:		Narrative
 	Concept:		TBD
@@ -56,18 +63,12 @@ Concept:		TBD
 Description:	"Elements that belong to all information items."
 0..1			VersionId
 0..1			LastUpdated
-0..*			EntryType // would EntryConformance be clearer?
 0..*			SecurityLabel
 0..*			Tag
 //0..1			RecordStatus
 0..1			InformationSource
 0..1			InformationRecorder
 0..1			AuthoredDateTime
-
-	Element:		EntryType  // Would EntryClass be clearer?
-	Concept:		TBD
-	Description:	"The class of the item, as a URI."
-	Value:			uri
 
 	Element:		RecordStatus
 	Description:	"Concept indicating the state of this record, e.g., entered in error."
@@ -150,11 +151,6 @@ Description:	"A composition represents a set of Entries sharing common provenanc
 
 
 /*
-	Element:		ShrId
-	Concept:		TBD
-	Description:	"A unique, persistent, permanent identifier for the overall health record belonging to the Patient."
-	Value:			id
-
 	Element:    	HealthRecordId
 	Concept:        MTH#C1549718
 	Description:    "A unique, persistent, permanent identifier for a health record."

--- a/spec/shr_base_map_dstu2.txt
+++ b/spec/shr_base_map_dstu2.txt
@@ -5,11 +5,11 @@ Target:		FHIR_DSTU_2
 //Entry maps to DomainResource:
 
 InformationItem maps to DomainResource:
-	EntryId maps to id
+	_Entry.EntryId maps to id
 	Language maps to language
 	Narrative maps to text
 	Metadata.VersionId maps to meta.versionId
-	Metadata.EntryType maps to meta.profile
+	// _Entry.EntryType maps to meta.profile // (this will force a profile -- don't do it)
 	Metadata.LastUpdated maps to meta.lastUpdated
 	Metadata.SecurityLabel maps to meta.security
 	Metadata.Tag maps to meta.tag

--- a/spec/shr_base_map_stu3.txt
+++ b/spec/shr_base_map_stu3.txt
@@ -5,11 +5,11 @@ Target:		FHIR_STU_3
 //Entry maps to DomainResource:
 
 InformationItem maps to DomainResource:
-	EntryId maps to id
+	_Entry.EntryId maps to id
 	Language maps to language
 	Narrative maps to text
 	Metadata.VersionId maps to meta.versionId
-	Metadata.EntryType maps to meta.profile
+	// _Entry.EntryType maps to meta.profile // (this will force a profile -- don't do it)
 	Metadata.LastUpdated maps to meta.lastUpdated
 	Metadata.SecurityLabel maps to meta.security
 	Metadata.Tag maps to meta.tag


### PR DESCRIPTION
This PR is needed to get the SHR tooling working correctly, since it depends on `Entry`.  It adds back the `ShrId`, `EntryId`, and `EntryType` fields to `Entry` and removes them from the other places they had been moved to.  It also forces `Entry` ES6 classes to be generated by including `shr.base.Entry` in the config filter.

In the (nearish) future, `Entry` and its fields should be a detail of the implementation -- not a detail of the models.