### PR TITLE
Cancer progression and terminology

### DIFF
--- a/spec/IndexFolder_Oncocore/terminology.html
+++ b/spec/IndexFolder_Oncocore/terminology.html
@@ -4,7 +4,29 @@
 
 <h1><a name="Terminology Overview"></a>Terminology Overview</h1>
 
-<h2>TBD</h2>
-<p></p>
+<h2>Terminology Approach</h2>
 
-<p>&nbsp;</p>
+<p>This implementation guide supplies terminology bindings drawn primarily from LOINC for "observables", and SNOMED-CT for values, results and findings. There are a few exceptions to this: </p>
+    <ul>
+        <li>When appropriate codes are not available in the preferred vocabulary, alternative vocabularies are used, in the following order of preference: SNOMED-CT (if the element is an observable), NCI Metathesaurus, and local codes;
+        </li>
+        <li>When LOINC is used to specify an observable and LOINC specifies a normative answer list for that term, the normative list is used instead of an equivalent SNOMED CT value set.</li>
+    </ul>
+
+<h2>FHIR Terminology</h2>
+
+<p>Value sets from the FHIR specification are reused to the extent possible. Specifically, and while this guide was produced for FHIR DSTU2, the model makes an attempt to provide seemless integration of multiple FHIR versions. This </p>
+
+<h2>Local Value Sets</h2>
+
+<p>This guide includes multiple value sets created specifically to support the terminology needs of the models. These value sets where created only when no known existing value sets were deemed to be fit for purpose, or when existing value needs needed to be extended.</p>
+
+<p><strong>There is a known issue with HL7's FHIR implementation guide publisher that causes an error in the expansion of local value sets in the implementation guide. While this prevents the value sets from being shown in the value set pages, the content of the value sets is correctly expanded in json and xml, which readers can access from the indivual value set pages.</strong></p>
+
+<h2>Exception Values</h2>
+
+<p>FHIR structurally separates missing value reasons (exception values) from answer sets. For example, FHIR uses two attributes, Observation.value and Observation.dataAbsentReason. For this reason, when LOINC answer lists included missing value explanations, those answers were separated and placed in a separate value set.&nbsp;However, we note that LOINC answer sets are not very consistent with regard to missing value reasons, and possibly incomplete. This leaves open a question on what a cross-cutting normative set of missing value reasons or exception values might be.</p>
+
+<h2>Cancer Staging and Proprietary Terminologies</h2>
+
+<p>The AJCC staging system is recognized as one of the most widely-used standards for cancer staging. However, this guide does not include any AJCC terminology due to unresolved copyright issues. As such, <strong>elements related to staging may not currently include required terminology bindings</strong>.</p>

--- a/spec/ig-breast-config.json
+++ b/spec/ig-breast-config.json
@@ -26,7 +26,7 @@
 		"strategy": "namespace",
 		"target": ["oncology"]
 	},
-    "publisher": "The MITRE Corporation",
+    "publisher": "The HL7 Cancer Interoperability Group sponsored by Clinical Interoperability Council Work Group (CIC)",
     "contact": [
         {
             "telecom": [

--- a/spec/ig-breast-config.json
+++ b/spec/ig-breast-config.json
@@ -26,7 +26,7 @@
 		"strategy": "namespace",
 		"target": ["oncology"]
 	},
-    "publisher": "The HL7 Cancer Interoperability Group sponsored by Clinical Interoperability Council Work Group (CIC)",
+    "publisher": "The MITRE Corporation",
     "contact": [
         {
             "telecom": [

--- a/spec/ig-oncocore-config.json
+++ b/spec/ig-oncocore-config.json
@@ -25,7 +25,7 @@
 		"strategy": "hybrid",
 		"target": ["oncocore", "shr.base.Entry"]
 	},
-    "publisher": "The HL7 Cancer Interoperability Group sponsored by Clinical Interoperability Council Work Group (CIC)",
+    "publisher": "The MITRE Corporation",
     "contact": [
         {
             "telecom": [

--- a/spec/shr_base_finding.txt
+++ b/spec/shr_base_finding.txt
@@ -166,7 +166,7 @@ Description:	"An observation with components, but without a result value or pane
 EntryElement:	LaboratoryObservation
 Based on:		Observation
 Description:	"A coded finding based on a specimen collected from a patient."
-				Code from LaboratoryCodeVS if covered
+				Code from http://loinc.org/vs if covered
 1..1			Category   // MK changed from 1..* to 1..1 to be compatible with DSTU 2
 1..1			Patient
 0..1			Specimen

--- a/spec/shr_base_vs.txt
+++ b/spec/shr_base_vs.txt
@@ -1,39 +1,39 @@
 Grammar:	ValueSet 5.0
 Namespace:	shr.base
 
-CodeSystem:      SCT = http://snomed.info/sct
-CodeSystem:		MTH = http://ncimeta.nci.nih.gov
-CodeSystem:     LNC = http://loinc.org
+CodeSystem:     SCT     = http://snomed.info/sct
+CodeSystem:		MTH     = http://ncimeta.nci.nih.gov
+CodeSystem:     LNC     = http://loinc.org
+CodeSystem:     HL7DAR  = http://terminology.hl7.org/CodeSystem/data-absent-reason
 
 
 ValueSet: 					DataAbsentReasonVS
 Description:				"Reasons that a value associated with a test or other finding is missing. Includes all codes from 	http://hl7.org/fhir/ValueSet/data-absent-reason version 3.3.0 and additional codes covering other missing value circumstances."
-#unknown					"Unknown: The value is not known."
-#asked-unknown				"Asked But Unknown: The source human does not know the value."
-#temp-unknown				"Temporarily Unknown: There is reason to expect (from the workflow) that the value may become known."
-#not-asked					"Not Asked: The workflow didn't lead to this value being known."
-#asked-declined				"Asked But Declined: The source was asked but declined to answer."
-#masked						"Masked: The information is not available due to security, privacy or related reasons."
-#not-applicable				"Not Applicable: There is no proper value for this element (e.g. last menstrual period for a male)"
-#unsupported				"Unsupported: The source system wasn't capable of supporting this element."
-#as-text					"As Text: The content of the data is represented in the resource narrative."
-#error						"Error: Some system or workflow process error means that the information is not available."
-#not-a-number				"Not a Number (NaN): The numeric value is undefined or unrepresentable due to a floating point processing error."
-#negative-infinity			"Negative Infinity (NINF): The numeric value is excessively low and unrepresentable due to a floating point processing error."
-#positive-infinity			"Positive Infinity (PINF): The numeric value is excessively high and unrepresentable due to a floating point processing error."
-#not-performed				"Not Performed: The value is not available because the observation procedure  (test, etc.) was not performed."
-#not-permitted				"Not Permitted: The value is not permitted in this context (e.g. due to profiles, or the base data types)"
+HL7DAR#unknown              "Unknown"
+HL7DAR#asked-unknown		"Asked But Unknown"
+HL7DAR#temp-unknown			"Temporarily Unknown"
+HL7DAR#not-asked			"Not Asked"
+HL7DAR#asked-declined		"Asked But Declined"
+HL7DAR#masked				"Masked"
+HL7DAR#not-applicable		"Not Applicable"
+HL7DAR#unsupported			"Unsupported"
+HL7DAR#as-text				"As Text"
+HL7DAR#error				"Error"
+HL7DAR#not-a-number			"Not a Number (NaN)"
+HL7DAR#negative-infinity	"Negative Infinity (NINF)"
+HL7DAR#positive-infinity	"Positive Infinity (PINF)"
+HL7DAR#not-performed		"Not Performed"
+HL7DAR#not-permitted		"Not Permitted"
 // The following values are extensions to the FHIR values, applicable to lab tests
+#insufficient-evidence      "There is insufficient information to make a determination."
+/* RM: these came from CIMI/Intermountain, commenting out until proven necessary.
 #indeterminate-value		"The value could not be determined or established with accuracy or certainty."
 #no-further-explanation		"The reason the information is not present is not known."
 #null-answer		        "The answer is appears missing because the correct answer is null or empty; e.g., a question that asks for a list of the names of siblings applied to an only child."
 #specimen-unavailable       "Missing due to a problem collecting, identifying, or locating the specimen, including patient refusal or unable to provide specimen"
 #specimen-inadequate		"Missing due to a problem with the specimen, e.g. inadequate specimen, contamination, clotting, improper tube type, improper storage, too small, etc."
 #instrument-malfunction		"Missing due to instrument malfunction."
-
-ValueSet:            LaboratoryCodeVS
-Description:         "Laboratory codes drawn from LOINC."
-                    Includes codes from LNC
+*/
 
 ValueSet:				ConditionCategoryVS
 Description:            "A category assigned to the condition, for example, a disease, concern, symptom, adverse reaction, functional impairment, or structural abnormality."

--- a/spec/shr_oncocore_vs.txt
+++ b/spec/shr_oncocore_vs.txt
@@ -27,20 +27,19 @@ Description:	"The morphologic behavior of the cancer. These are the suffix to th
 
 ValueSet:   CancerProgressionVS   
 Description: "The course of a disease, such as cancer, as it becomes worse or spreads in the body. (source: NCI Dictionary)"
-MTH#C0677874	"Complete response or remission; no measurable or observable evidence of cancer."  // SCT#103338009 In full remission (qualifier value)
-MTH#C0015250	"Complete resection/excision of cancerous tumor"  // ?? SCT#79095000 Complete excision of organ (procedure)
-MTH#C1272745	"Improving, responding to treatment"  // SCT#385633008 Improving (qualifier value)
-MTH#C0205360	"Stable, neither improving nor worsening"  // SCT#58158008  Stable (qualifier value)
-MTH#C1546960	"Worsening, disease progressing"   // SCT#230993007  Worsening (qualifier value)
-MTH#C3858734	"Insufficient evidence"
+SCT#103338009 "In full remission (qualifier value)"
+SCT#385633008 "Improving (qualifier value)"
+SCT#58158008  "Stable (qualifier value)"
+SCT#230993007  "Worsening (qualifier value)"
 
-ValueSet:		CancerProgressionEvidenceVS
-Description:    "The type of evidence backing up the clinical determination of cancer progression."
-MTH#C0011923 	"Cancer progression determined based on imaging"
-MTH#C0030664	"Cancer progression determined based on pathology"
-MTH#C1457887  	"Cancer progression determined based on physical signs or symptoms"
-MTH#C0031809	"Cancer progression determined based on physical examination"
-MTH#C0005516	"Cancer progression determined based on biomarkers"
+ValueSet:		  CancerProgressionEvidenceVS
+Description:  "The type of evidence backing up the clinical determination of cancer progression."
+//SCT codes are all children of the SCT#386053000 "Evaluation procedure (procedure)"
+SCT#363679005 "Imaging (procedure)"
+SCT#252416005 "Histopathology test (procedure)"
+SCT#711015009 "Assessment of symptom control (procedure)"
+SCT#5880005   "Physical examination procedure (procedure)"
+MTH#C0005516	"Biological markers"
 
 ValueSet:		CancerStageTimingVS
 //TODO: the value set is missing codes for recurrence and anatomical staging.
@@ -65,7 +64,6 @@ Description:    "System used for TNM classification."
   SCT#443830009 "American Joint Commission on Cancer, Cancer Staging Manual, 7th edition neoplasm staging system (tumor staging)"
   #AJCC8 "American Joint Commission on Cancer, Cancer Staging Manual, 8th edition neoplasm staging system (tumor staging)"
   SCT#258235000 "International Union Against Cancer (tumor staging)"
-
 
 ValueSet:   CancerStageSuffixVS
 Description: "Modifiers related to the staging category. Examples of modifiers include the type of procedure performed in determining the pathological node classification. The staging suffix notation is the abbreviation enclosed by parentheses.  For example, CN1a(sn) where (sn) designates that the N category was identified based on a sentinel node biopsy."


### PR DESCRIPTION
- Replaced MTH/local codes with SCT codes, where possible, in `CancerProgressionVS` and `CancerProgressionEvidenceVS`.
- Replaced local codes in `ExceptionValueVS` with externally defined codes in the data-absent-reason FHIR value set and extended the value set to support "lack of evidence" to complement the `CancerProgressionEvidenceVS` per our discussion with the iCareData team.
- Replaced reference to non-existing `LaboratoryCodeVS` with direct reference to LOINC. The value sets existed in a previous version of `dev` and was throwing an CLI error. It contained all the codes in LOINC.
- Populated terminology page for oncocore IG.
- Made MITRE the publisher for the oncocore IG.