### PR TITLE
Fix component mapping

### DIFF
--- a/spec/shr_finding_map_stu3.txt
+++ b/spec/shr_finding_map_stu3.txt
@@ -28,8 +28,8 @@ Observation maps to Observation:
 	ReferenceRange.Type maps to referenceRange.type
 	ReferenceRange.ApplicableSubpopulation maps to referenceRange.appliesTo
 	ReferenceRange.ApplicableAgeRange maps to referenceRange.age
-	Components maps to component 
-	Components.ObservationComponent.Code maps to component.code (slice on = code.coding.code; slice strategy = includes)
+	Components.ObservationComponent maps to component (slice on = code.coding.code; slice strategy = includes)
+	Components.ObservationComponent.Code maps to component.code
 	Components.ObservationComponent.DataValue maps to component.value[x]
 	Components.ObservationComponent.DataAbsentReason maps to component.dataAbsentReason
 	//Components.ObservationComponent.Interpretation maps to component.interpretation


### PR DESCRIPTION
Fixes the mapping of components to slice at the appropriate place.

NOTE: This works well is shr-fhir-export, but it triggers errors in shr-es6-export.  These errors are currently being investigated.