### PR TITLE
Fix mCODE content profile paths

### DIFF
--- a/spec/cp-mcode.txt
+++ b/spec/cp-mcode.txt
@@ -2,141 +2,141 @@ Grammar:        ContentProfile 1.0
 
 // Required fields (1..1 or 1..*) don't need to be marked must-support so (currently) they are not included in this list. But, I wonder if they will be missed in the data dictionary?
 Namespace: shr.core
-    Patient:  // Required (by US-Core): Identifier, Identifier.System, Identifier.Value, HumanName, HumanName.Family, HumanName.Given, AdministrativeGender 
+    Patient:  // Required (by US-Core): Identifier, Identifier.System, Identifier.Value, HumanName, HumanName.Family, HumanName.Given, AdministrativeGender
         Person.DateOfBirth MS
         Person.AdministrativeGender MS
-        Person.Race.RaceCode MS
-        Person.Ethnicity.EthnicityCode MS
+        Person.Race MS
+        Person.Ethnicity MS
         Person.Address.PostalCode MS
         // How to restrict out the boolean or make dateTime only MS in mCODE only?
         Person.Deceased MS
     ComorbidCondition:
-        // Required: SubjectOfRecord, Category, Status, ClinicalStatus, Code
-        SubjectOfRecord MS
+        // Required: PatientSubjectOfRecord, Category, Status, ClinicalStatus, Code
+        PatientSubjectOfRecord MS
         Code MS
         ClinicalStatus MS
     MedicationStatement:
-        // Required: StatementDateTime, Medication, OccurrenceTimeOrPeriod, Status, SubjectOfRecord
-        SubjectOfRecord MS
-        MedicationCodeOrReference  MS  // Code only?  i.e., [CodeableConcept]? 
+        // Required: StatementDateTime, Medication, OccurrenceTimeOrPeriod, Status, PatientSubjectOfRecord
+        PatientSubjectOfRecord MS
+        MedicationCodeOrReference  MS  // Code only?  i.e., [CodeableConcept]?
         OccurrenceTimeOrPeriod  MS
         TerminationReason  MS
         TreatmentIntent  MS
     ECOGPerformanceStatus:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
         Interpretation MS
         RelevantTime MS
     KarnofskyPerformanceStatus:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
         Interpretation MS
         RelevantTime MS
     SurgicalProcedure:
-        SubjectOfRecord MS
+        ProcedureSubjectOfRecord MS
         Code MS
         OccurrenceTimeOrPeriod MS
         TreatmentIntent MS
         // BodyLocation unnecessary if code is pre-coordinated
-    RadiationProcedure:  
-        // Required: SubjectOfRecord, Status, OccurrenceTimeOrPeriod, Code
-        SubjectOfRecord MS
+    RadiationProcedure:
+        // Required: ProcedureSubjectOfRecord, Status, OccurrenceTimeOrPeriod, Code
+        ProcedureSubjectOfRecord MS
         Code MS
         OccurrenceTimeOrPeriod MS
         TreatmentIntent MS
         // BodyLocation unnecessary if code is pre-coordinated
-    BloodPressure: 
-        // Required: SubjectOfRecord, Category, Status and Code
-        SubjectOfRecord MS
+    BloodPressure:
+        // Required: PatientSubjectOfRecord, Category, Status and Code
+        PatientSubjectOfRecord MS
         Code MS
 // Uncomment out when ready
 //        Components.ObservationComponent[SystolicPressure].DataValue
 //        Components.ObservationComponent[DiastolicPressure].DataValue
         RelevantTime MS
     BodyHeight:
-        // Required: SubjectOfRecord, Category, Status and Code
-        SubjectOfRecord MS
+        // Required: PatientSubjectOfRecord, Category, Status and Code
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
         RelevantTime MS
     BodyWeight:
-        // Required: SubjectOfRecord, Category, Status and Code
-        SubjectOfRecord MS
+        // Required: PatientSubjectOfRecord, Category, Status and Code
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
         RelevantTime MS
 
 Namespace: oncocore
     CancerCondition:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         ClinicalStatus MS
         BodyLocation.LocationCode MS
         MorphologyBehavior MS
         DateOfDiagnosis MS
-        CancerHistologicType MS
+        // CancerHistologicType MS // CM: not a valid field
     DistantMetastases:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DateOfDiagnosis MS
         //  No BodyLocation because ICD-O-3 code will pre-coordinate body site
 
-//  For all TNM elements, Required: Code, Status, SubjectOfRecord
+//  For all TNM elements, Required: Code, Status, PatientSubjectOfRecord
 //  Issue: The data element code is fixed in the profile. It serves as an identifier of the element, which comes across the wire as an anonymous Observation. Therefore, some identification is needed. Should we required that the profile URI goes into meta.profile? Or require the code? Or both? For now, require the code.)
     TNMClinicalStageGroup:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
         Method MS
         RelevantTime MS
     TNMClinicalPrimaryTumorClassification:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
-        CancerStageSuffix MS
+        // CancerStageSuffix MS // CM: not a valid field
         CancerStageTiming MS
         RelevantTime MS
     TNMClinicalRegionalNodesClassification:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
-        CancerStageSuffix MS
+        // CancerStageSuffix MS // CM: not a valid field
         CancerStageTiming MS
         RelevantTime MS
     TNMClinicalDistantMetastasesClassification:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
-        CancerStageSuffix MS
+        // CancerStageSuffix MS // CM: not a valid field
         CancerStageTiming MS
         RelevantTime MS
     TNMPathologicStageGroup:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
         Method MS
         RelevantTime MS
     TNMPathologicPrimaryTumorClassification:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
-        CancerStageSuffix MS
+        // CancerStageSuffix MS // CM: not a valid field
         CancerStageTiming MS
         RelevantTime MS
     TNMPathologicRegionalNodesClassification:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
-        CancerStageSuffix MS
+        // CancerStageSuffix MS // CM: not a valid field
         CancerStageTiming MS
         RelevantTime MS
     TNMPathologicDistantMetastasesClassification:
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
-        CancerStageSuffix MS
+        // CancerStageSuffix MS // CM: not a valid field
         CancerStageTiming MS
         RelevantTime MS
     TumorMarkerObservation:
@@ -150,18 +150,18 @@ Namespace: oncocore
         // Required: Code, Status, Category, SubjectOfRecord
         SubjectOfRecord MS
         Code MS
-        DNARegionName MS
-        DNASequenceVariantId.DataValue MS
-        DNASequenceVariantName.DataValue MS
-        DNASequenceVariantType.DataValue MS
-        GeneName MS
-        GenomicSourceClass MS
+        // Components.ObservationComponent[DNARegionName] MS                    // CM: includes type not yet supported in CP
+        // Components.ObservationComponent[DNASequenceVariantId].DataValue MS   // CM: includes type not yet supported in CP
+        // Components.ObservationComponent[DNASequenceVariantName].DataValue MS // CM: includes type not yet supported in CP
+        // Components.ObservationComponent[DNASequenceVariantType].DataValue MS // CM: includes type not yet supported in CP
+        // Components.ObservationComponent[GeneName] MS                         // CM: includes type not yet supported in CP
+        // Components.ObservationComponent[GenomicSourceClass] MS               // CM: includes type not yet supported in CP
         Method MS
         RelevantTime MS
         Specimen.Type  MS // ??
     CancerDiseaseStatus:
-        // Required: Code, Status, SubjectOfRecord
-        SubjectOfRecord MS
+        // Required: Code, Status, PatientSubjectOfRecord
+        PatientSubjectOfRecord MS
         Code MS
         DataValue MS
         EvidenceType MS
@@ -169,28 +169,23 @@ Namespace: oncocore
 
 Namespace: shr.lab
     CBCWAutoDifferentialPanel:
-        // Required: Code, Status, Category, SubjectOfRecord
-        SubjectOfRecord MS
+        // Required: Code, Status, Category, PatientSubjectOfRecord
+        PatientSubjectOfRecord MS
         Code MS
 //   Uncomment when supported
 //        PanelMembers.Observation[CBCMustSupportPanelMember]
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         RelevantTime MS
     ComprehensiveMetabolic2000SerumOrPlasmaPanel:
-        // Required: Code, Status, Category, SubjectOfRecord
-        SubjectOfRecord MS    
+        // Required: Code, Status, Category, PatientSubjectOfRecord
+        PatientSubjectOfRecord MS
         Code MS
 //   Uncomment when supported
 //        PanelMembers.Observation[CMPMustSupportPanelMember]
-        SubjectOfRecord MS
+        PatientSubjectOfRecord MS
         RelevantTime MS
     CMP2000SerumOrPlasmaCoreElement:
          // Required: Code, Status, Category, SubjectOfRecord
-        SubjectOfRecord MS
-        Code MS
-        DataValue MS
-    CMP2000SerumOrPlasmaCoreElement:
-        // Required: Code, Status, Category, SubjectOfRecord
         SubjectOfRecord MS
         Code MS
         DataValue MS


### PR DESCRIPTION
Fix paths in the content profile.  Most fixes fall under one of these categories
- paths used parent type name instead of constrained type name (e.g., SubjectOfRecord instead of PatientSubjectOfRecord)
- paths referred to fields that didn't exist at all (e.g., CancerStageSuffix)
- paths referred to include types (e.g., DNARegionName)
- paths referred to nested fields that weren't mapped (e.g., Person.Race.RaceCode)

This fixes most of the errors reported by my implementation of `must supports` in the FHIR exporter -- but there are still a few more to go.  That said, I think the remaining issues need to be fixed in the exporter, not the CP file.