### PR TITLE
Changed R4 mappings to US Core v3 profiles

### DIFF
--- a/spec/obf_allergy_map_r4.txt
+++ b/spec/obf_allergy_map_r4.txt
@@ -2,7 +2,7 @@ Grammar:	Map 5.1
 Namespace:	obf
 Target:		FHIR_R4
 
-AllergyIntolerance maps to AllergyIntolerance:
+AllergyIntolerance maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance:
 	Identifier maps to identifier
 	SubjectOfRecord maps to patient
 	PersonInformationSource maps to asserter // Added Target Type PractitionerRole

--- a/spec/obf_encounter.txt
+++ b/spec/obf_encounter.txt
@@ -41,6 +41,8 @@ Property:          EncounterLocation 0..*
 Property:          PartOf 0..1
                    Participation.Participant substitute EncounterParticipant
                    PartOf[Resource] substitute Encounter
+                   // US Core v3 requires at least 1 Encounter type
+                   Type 1..*
                    Type from http://hl7.org/fhir/ValueSet/v3-ActEncounterCode (extensible)
                    BasedOn substitute ReferralBasedOn
                    PriorityCode from http://hl7.org/fhir/ValueSet/v3-ActPriority (example)

--- a/spec/obf_encounter_map_r4.txt
+++ b/spec/obf_encounter_map_r4.txt
@@ -2,7 +2,7 @@ Grammar:	Map 5.1
 Namespace:	obf
 Target:		FHIR_R4
 
-Encounter maps to Encounter:
+Encounter maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter:
 	Identifier maps to identifier
 	Status maps to status 
 	StatusHistory maps to statusHistory

--- a/spec/obf_entity_map_r4.txt
+++ b/spec/obf_entity_map_r4.txt
@@ -2,7 +2,7 @@ Grammar:	Map 5.1
 Namespace:	obf
 Target:		FHIR_R4
 
-Patient maps to Patient:
+Patient maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient:
 	Identifier maps to identifier
 	Active maps to active
 	HumanName maps to name
@@ -31,7 +31,7 @@ Patient maps to Patient:
 	Race maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-race
 	Ethnicity maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity
 
-Practitioner maps to Practitioner:
+Practitioner maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner:
 	Identifier maps to identifier (slice on = type.coding.code; slice strategy = includes)
 	Active maps to active
 	HumanName maps to name
@@ -61,7 +61,7 @@ RelatedPerson maps to RelatedPerson:
 	EffectiveTimePeriod maps to period
 	Communication maps to communication
 	
-Organization maps to Organization:
+Organization maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization:
 	Identifier maps to identifier
 	Active maps to active
 	Name maps to name
@@ -89,7 +89,7 @@ Group maps to Group:
 	GroupParticipation.Inactive maps to member.inactive
 	ManagingEntity maps to managingEntity
 	
-Location maps to Location:
+Location maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-location:
 	Identifier maps to identifier
 	Status maps to status 
 	OperationalStatus maps to operationalStatus
@@ -122,7 +122,7 @@ Substance maps to Substance:
 	Ingredient.IngredientStrength maps to ingredient.quantity
 	Ingredient.SubstanceOrCode maps to ingredient.substance[x]
 
-Medication maps to Medication:
+Medication maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication:
 	Identifier maps to identifier  // added identifier
 	Code maps to code
 	Status maps to status
@@ -160,7 +160,7 @@ Specimen maps to Specimen:
 	SpecimenContainer.Additive maps to container.additive[x]
 // Added collection.duration, collection.fastingStatus[x], condition
 
-Device maps to Device:
+Device maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-device:
 	Identifier maps to identifier
 	UdiCarrier.DeviceIdentifier maps to udiCarrier.deviceIdentifier
 	UdiCarrier.CarrierAIDC maps to udiCarrier.carrierAIDC
@@ -217,4 +217,4 @@ Media maps to Media:
     Attachment maps to content
     Annotation maps to note
 
-PractitionerRole maps to PractitionerRole:
+PractitionerRole maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole:

--- a/spec/obf_finding.txt
+++ b/spec/obf_finding.txt
@@ -272,7 +272,8 @@ Entry:             DiagnosticReport
 Parent:            SituationStatement
 Description:       "The findings and interpretation of diagnostic tests performed on patients, groups of patients, devices, and locations, and/or specimens derived from these. The report includes clinical context such as requesting and provider information, and some mix of atomic results, images, textual and coded interpretations, and formatted representation of diagnostic reports."
 Property:          BasedOn 0..*
-Property:          Category 0..1
+// Category is 0..1 in DSTU 2 and 1..* in US-Core v3. Therefore must be 1..1.
+Property:          Category 1..1
 Property:          RelevantTime 0..1
 Property:          DiagnosticReportPerformer 0..1
 Property:          ResultsInterpreter 0..1
@@ -286,10 +287,19 @@ Property:          PresentedForm 0..*
                    // 'issued' is required in DSTU-2
                    Status 1..1
                    Status from http://hl7.org/fhir/ValueSet/diagnostic-report-status (required)
+                   // SubjectOfRecord is required in US Core v3
+                   SubjectOfRecord 1..1
                    SubjectOfRecord substitute ObservationSubjectOfRecord
                    CareContext only Encounter
                    StatementDateTime 1..1
-                   Code from http://hl7.org/fhir/ValueSet/report-codes (preferred)
+                   // US Core v3 uses extensible binding to http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes, but this contains all of LOINC, just like http://hl7.org/fhir/ValueSet/report-codes
+                   Code from http://hl7.org/fhir/ValueSet/report-codes (extensible)
+
+Entry:             LaboratoryReport
+Parent:            DiagnosticReport
+Description:       "A grouping or summarization of laboratory results, where individual results are typically Observations or nested Observations (panels). This class aligns with US Core DiagnosticReport Profile for Laboratory Results Reporting."
+                   // result must map to http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab in R4
+                   Observation substitute LaboratoryObservation
 
 Entry:             SimpleCodedNonLaboratoryObservation
 Parent:            CodedNonLaboratoryObservation

--- a/spec/obf_finding_map_r4.txt
+++ b/spec/obf_finding_map_r4.txt
@@ -48,11 +48,11 @@ Observation maps to Observation:
 	Components.ObservationComponent.ReferenceRange.ApplicableAgeRange maps to component.referenceRange.age
 	Components.ObservationComponent.ReferenceRange.Text maps to component.referenceRange.text
 
-LaboratoryObservation maps to Observation:
+LaboratoryObservation maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab:
 	Identifier maps to identifier (slice on = type.coding.code; slice strategy = includes)
 //	Performer maps to performer (slice on = target.reference.resolve(); slice on type = profile; slice strategy = includes) -- see note in LaboratoryObservation about slicing Performer
 
-Condition maps to Condition:
+Condition maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition:
 	Identifier maps to identifier
 	ClinicalStatus maps to clinicalStatus
 	Status maps to verificationStatus
@@ -79,7 +79,27 @@ Condition maps to Condition:
 	Annotation maps to note
 	DateOfDiagnosis maps to extension
 
-DiagnosticReport maps to DiagnosticReport:
+DiagnosticReport maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note:
+	Identifier maps to identifier
+	BasedOn maps to basedOn
+	Status maps to status
+	Category maps to category
+	ObservationSubjectOfRecord maps to subject
+	Code maps to code
+	CareContext maps to encounter
+	RelevantTime maps to effective[x]
+	StatementDateTime maps to issued
+	DiagnosticReportPerformer maps to performer
+	ResultsInterpreter maps to resultsInterpreter
+	Specimen maps to specimen
+	Observation maps to result (slice on = target.reference.resolve(); slice on type = profile; slice strategy = includes)
+	MediaIncluded.CommentOrDescription maps to media.comment
+	MediaIncluded.Media maps to media.link
+    ConclusionText maps to conclusion
+	ConclusionCode maps to conclusionCode
+	PresentedForm maps to presentedForm
+
+LaboratoryReport maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab:
 	Identifier maps to identifier
 	BasedOn maps to basedOn
 	Status maps to status

--- a/spec/obf_foundation.txt
+++ b/spec/obf_foundation.txt
@@ -157,7 +157,8 @@ Compatibility: US Core"
 Property:          MasterIdentifier 0..1
 Property:          DocumentStatus 0..1
 Property:          Type 1..1
-Property:          Category 0..1
+// US Core v3 requires at least one Category
+Property:          Category 1..1
 Property:          DocumentAuthor 0..*
 Property:          Authenticator 0..1
 Property:          ManagingOrganization 0..1
@@ -165,17 +166,22 @@ Property:          ManagingOrganization 0..1
 Property:          RelatedDocument 0..*
 Property:          CommentOrDescription 0..1
 Property:          SecurityLabel 0..*
-                   // content
-Property:          DocumentReferenced 1..*
+                   // US Core v3 sets upper cardinality of 1 on DocumentReferenced (aka content)
+Property:          DocumentReferenced 1..1
                    // context
 Property:          EventContext 0..1
+                   // US Core v3 limits identifier to 0..1 (this is a mistake in US Core, IMO)
+                   Identifier 0..1
                    Status 1..1
                    StatementDateTime 1..1
                    Status from http://hl7.org/fhir/ValueSet/document-reference-status (required)
                    DocumentStatus from http://hl7.org/fhir/ValueSet/composition-status (required)
-                   Type from http://hl7.org/fhir/ValueSet/c80-doc-typecodes (required)
+                   Type from http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type (required)
+                   //Type from http://hl7.org/fhir/ValueSet/c80-doc-typecodes (preferred)
                    Category from http://hl7.org/fhir/ValueSet/c80-doc-classcodes (required)
-                   // us core restriction 
+                   // US Core v3 restriction
+                   SubjectOfRecord 1..1
+                   // US Core restriction 
                    SubjectOfRecord only Patient
                    RelatedDocument.TargetDocument only DocumentReference
                    SecurityLabel from http://hl7.org/fhir/ValueSet/security-labels (extensible)

--- a/spec/obf_foundation_map_dstu2.txt
+++ b/spec/obf_foundation_map_dstu2.txt
@@ -2,11 +2,9 @@ Grammar:	Map 5.1
 Namespace:	obf
 Target:		FHIR_DSTU_2
 
-
-DomainResource maps to DomainResource:
+Resource maps to Resource:
 //	_Entry.EntryId maps to id
 	Language maps to language
-	Narrative maps to text
 	ImplicitRules maps to implicitRules
 	Metadata.VersionId maps to meta.versionId
 	Metadata.SourceSystem maps to meta.extension
@@ -15,6 +13,9 @@ DomainResource maps to DomainResource:
 	Metadata.LastUpdated maps to meta.lastUpdated
 	Metadata.SecurityLabel maps to meta.security
 	Metadata.Tag maps to meta.tag
+
+DomainResource maps to DomainResource:
+	Narrative maps to text
 
 Composition maps to Composition:
 	Identifier maps to identifier

--- a/spec/obf_foundation_map_r4.txt
+++ b/spec/obf_foundation_map_r4.txt
@@ -126,7 +126,7 @@ ValueSet maps to ValueSet:
     // compose.include.concept.designation.language	-- Change binding strength from extensible to preferred
 
 
-DocumentReference maps to DocumentReference:
+DocumentReference maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference:
     MasterIdentifier maps to masterIdentifier
     Identifier maps to identifier
     Status maps to status

--- a/spec/obf_foundation_map_stu3.txt
+++ b/spec/obf_foundation_map_stu3.txt
@@ -2,10 +2,9 @@ Grammar:	Map 5.1
 Namespace:	obf
 Target:		FHIR_STU_3
 
-DomainResource maps to DomainResource:
+Resource maps to Resource:
 //	_Entry.EntryId maps to id
 	Language maps to language
-	Narrative maps to text
 	ImplicitRules maps to implicitRules
 	Metadata.VersionId maps to meta.versionId
 	Metadata.SourceSystem maps to meta.extension 
@@ -15,6 +14,9 @@ DomainResource maps to DomainResource:
 	Metadata.LastUpdated maps to meta.lastUpdated
 	Metadata.SecurityLabel maps to meta.security
 	Metadata.Tag maps to meta.tag
+
+DomainResource maps to DomainResource:
+	Narrative maps to text
 
 Composition maps to Composition:
 	Identifier maps to identifier

--- a/spec/obf_medication_map_r4.txt
+++ b/spec/obf_medication_map_r4.txt
@@ -19,7 +19,7 @@ Dosage maps to Dosage:
 	DoseAndRate.DoseAmount maps to doseAndRate.dose[x]
 	DoseAndRate.DoseRate maps to doseAndRate.rate[x]
 
-MedicationStatement maps to MedicationStatement:
+MedicationStatement maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationstatement:
 	Identifier maps to identifier
 	MedicationBasedOn maps to basedOn
 	MedicationStatementPartOf maps to partOf
@@ -69,7 +69,7 @@ MedicationAdministration maps to MedicationAdministration:
 	Dosage.InstructionCode maps to dosage.extension
 
 
-MedicationRequest maps to MedicationRequest:
+MedicationRequest maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest:
 	Identifier maps to identifier
 	Status maps to status
 	StatusReason maps to statusReason

--- a/spec/obf_procedure_map_r4.txt
+++ b/spec/obf_procedure_map_r4.txt
@@ -3,7 +3,7 @@ Namespace:	obf
 Target:		FHIR_R4
 
 
-Procedure maps to Procedure:
+Procedure maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure:
 	Identifier maps to identifier
 	ProcedureBasedOn maps to basedOn 
 	ProcedurePartOf maps to partOf  // add Observation, MedicationAdministration

--- a/spec/oncocore_genetics.txt
+++ b/spec/oncocore_genetics.txt
@@ -49,7 +49,8 @@ FHIR implementation note: The category for this profile is set to GE (Genetics),
 Property:          SpecimenType 0..1
 Property:          RegionStudied 0..*
                    ObservationSubjectOfRecord only Patient
-                   Code from https://www.ncbi.nlm.nih.gov/gtr (preferred)
+                   // US Core v3 requires an extensible binding to Code
+                   Code from https://www.ncbi.nlm.nih.gov/gtr (extensible)
                    Category 1..1
                    Category = UNK1#GE
                    Observation


### PR DESCRIPTION
These updates bring US into the R4 mappings, so mCODE, ODH, and other IGs will be compatible with US Core V3 (the release of US Core that is based on FHIR R4). Certain binding strengths and cardinalities were changed to conform with US Core. 