### PR TITLE
fixed sub-bullets, examples, and documentation

### DIFF
--- a/spec/Examples_mCODE_dstu2/mCODEPrimaryCancerConditionExample01.json
+++ b/spec/Examples_mCODE_dstu2/mCODEPrimaryCancerConditionExample01.json
@@ -42,10 +42,6 @@
   "onsetDateTime": "2019-04-01",
   "extension": [
     {
-      "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/obf-DateOfDiagnosis-extension",
-      "valueDate": "2019-04-01"
-    },
-    {
       "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/onco-core-HistologyMorphologyBehavior-extension",
       "valueCodeableConcept": {
         "coding": [

--- a/spec/Examples_mCODE_dstu2/mCODEPrimaryCancerConditionExample02_dstu2.json
+++ b/spec/Examples_mCODE_dstu2/mCODEPrimaryCancerConditionExample02_dstu2.json
@@ -42,10 +42,6 @@
   "onsetDateTime": "2019-05-01",
   "extension": [
     {
-      "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/obf-DateOfDiagnosis-extension",
-      "valueDate": "2019-05-01"
-    },
-    {
       "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/onco-core-HistologyMorphologyBehavior-extension",
       "valueCodeableConcept": {
         "coding": [

--- a/spec/Examples_mCODE_r4/mCODEPrimaryCancerConditionExample01.json
+++ b/spec/Examples_mCODE_r4/mCODEPrimaryCancerConditionExample01.json
@@ -62,10 +62,6 @@
   "onsetDateTime": "2019-04-01",
   "extension": [
     {
-      "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/obf-DateOfDiagnosis-extension",
-      "valueDate": "2019-04-01"
-    },
-    {
       "url": "http://hl7.org/fhir/us/mcode/StructureDefinition/onco-core-HistologyMorphologyBehavior-extension",
       "valueCodeableConcept": {
         "coding": [

--- a/spec/Examples_mCODE_r4/mCODETNMClinicalDistantMetastasesCategoryExample01.json
+++ b/spec/Examples_mCODE_r4/mCODETNMClinicalDistantMetastasesCategoryExample01.json
@@ -8,7 +8,7 @@
   },
   "text": {
     "status": "generated",
-    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>*** mCODE Example: TNM Distant Metastases Category ***</b></p><p><b>Name</b>: John B. Anyperson </p><p><b>MRN</b>: m123 </p><p><b>Date</b>: 04/01/19 </p><p><b>Cancer staging system</b>: AJCC Version 8</p><p><b>M Category</b>: M0</p></div>"
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>*** mCODE Example: TNM Distant Metastases Category ***</b></p><p><b>Name</b>: John B. Anyperson </p><p><b>MRN</b>: m123 </p><p><b>Date</b>: 04/01/19 </p><p><b>Cancer staging system</b>: AJCC Version 8</p><p><b>M Category</b>: cM0</p></div>"
   },
   "status": "final",
   "category": [
@@ -43,7 +43,7 @@
     "coding": [
       {
         "system": "http://cancerstaging.org",
-        "code": "M0",
+        "code": "cM0",
         "display": "M0"
       }
     ]

--- a/spec/Examples_mCODE_r4/mCODETNMClinicalPrimaryTumorCategoryExample01.json
+++ b/spec/Examples_mCODE_r4/mCODETNMClinicalPrimaryTumorCategoryExample01.json
@@ -8,7 +8,7 @@
   },
   "text": {
     "status": "generated",
-    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>*** mCODE Example: TNM Primary Tumor Category ***</b></p><p><b>Name</b>: John B. Anyperson </p><p><b>MRN</b>: m123 </p><p><b>Date</b>: 04/01/19 </p><p><b>Cancer staging system</b>: AJCC Version 8</p><p><b>T category</b>: T3</p></div>"
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><p><b>*** mCODE Example: TNM Primary Tumor Category ***</b></p><p><b>Name</b>: John B. Anyperson </p><p><b>MRN</b>: m123 </p><p><b>Date</b>: 04/01/19 </p><p><b>Cancer staging system</b>: AJCC Version 8</p><p><b>T category</b>: cT3</p></div>"
   },
   "status": "final",
   "category": [
@@ -43,7 +43,7 @@
     "coding": [
       {
         "system": "http://cancerstaging.org",
-        "code": "T3",
+        "code": "cT3",
         "display": "T3"
       }
     ]

--- a/spec/Examples_mCODE_r4/mCODETNMClinicalRegionalNodesCategoryExample01.json
+++ b/spec/Examples_mCODE_r4/mCODETNMClinicalRegionalNodesCategoryExample01.json
@@ -43,11 +43,10 @@
     "coding": [
       {
         "system": "http://cancerstaging.org",
-        "code": "N3",
+        "code": "cN3",
         "display": "N3"
       }
-    ],
-    "text": "N3"
+    ]
   },
   "extension": [
     {

--- a/spec/IndexFolder_Oncocore/disease.html
+++ b/spec/IndexFolder_Oncocore/disease.html
@@ -46,6 +46,17 @@
 
 <p>Under the Fair Use doctrine, this IG provides examples illustrating mCODE's representation of cancer diagnoses and AJCC staging values for the purposes of technical implementation guidance to FHIR developers.</p>
 
+<h3>On representing staging category values</h3>
+Clinical applications vary in their representation of T, N, and M staging category values, falling into one of two naming conventions:
+<ul>
+    <li>prepended with a staging classification abbreviation (e.g.: <em>cT3</em>). This is the coding convention returned by AJCC in their digital data content retrieved via the <a href="https://ajcc.3scale.net/">AJCC Application Programming Interface (API)</a>.</li>
+    <li>without a prepended staging classification abbreviation (e.g.: <em>T3</em>)</li>
+</ul>
+
+mCODE recommends that the implementer align with using the staging category value with the <i><b>pre-pended classification</i></b>. This code convention is aligned with the AJCC's digital data and clearly distinguishes the staging classification as clinical, pathologic, or neoadjuvant without having to retrieve further context from the model. 
+
+<p>&nbsp;</p>
+
 <h2>Representing Comorbid Conditions</h2>
 <p>mCODE constrains the list of comorbid conditions that are relevant to cancer, and aligns with the <a href = "http://mchp-appserv.cpe.umanitoba.ca/concept/Elixhauser%20Comorbidities%20-%20Coding%20Algorithms%20for%20ICD-9-CM%20and%20ICD-10.pdf">Elixhauer Comorbidity Index</a> as its main source.</p>
 

--- a/spec/datatype_vs.txt
+++ b/spec/datatype_vs.txt
@@ -297,8 +297,8 @@ Body location is a flexible structure that allows the location to be determined 
 * Code only: The code should include (precoordinate) laterality and/orientation to the degree necessary to completely specify the body location.
 * Code plus laterality and/or orientation: The basic code augmented by codes specifying the body side and/or anatomical orientation.
 * Relation to landmark: The location relative to a landmark is specified by:
-  * Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
-  * Specifying the direction and distance from the landmark to the body location. 
+  1. Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
+  2. Specifying the direction and distance from the landmark to the body location. 
 
 Note that BodyLocation is a data type (a reusable structure), not a stand-alone entity. The concept is similar to how a postal address can apply to a person, location, or organization. This contrasts with FHIR's stand-alone BodySite (aka BodyStructure in r4) which 'is not ... intended for describing the type of anatomical location but rather a specific body site on a specific patient' (FHIR 3.5)."
 Includes codes descending from SCT#123037004  "Body Structure"
@@ -309,8 +309,8 @@ Description:    "Terms that specify the side of the body. The laterality value s
 * Code only: The code should include (precoordinate) laterality and/orientation to the degree necessary to completely specify the body location.
 * Code plus laterality and/or orientation: The basic code augmented by codes specifying the body side and/or anatomical orientation.
 * Relation to landmark: The location relative to a landmark is specified by:
-  * Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
-  * Specifying the direction and distance from the landmark to the body location. 
+  1. Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
+  2. Specifying the direction and distance from the landmark to the body location. 
 
 Note that BodyLocation is a data type (a reusable structure), not a stand-alone entity. The concept is similar to how a postal address can apply to a person, location, or organization. This contrasts with FHIR's stand-alone BodySite (aka BodyStructure in r4) which 'is not ... intended for describing the type of anatomical location but rather a specific body site on a specific patient' (FHIR 3.5)."
 SCT#419161000 	"Unilateral left"	
@@ -325,8 +325,8 @@ Description:       "Terms that specify anatomical orientation. The orientation v
 * Code only: The code should include (precoordinate) laterality and/orientation to the degree necessary to completely specify the body location.
 * Code plus laterality and/or orientation: The basic code augmented by codes specifying the body side and/or anatomical orientation.
 * Relation to landmark: The location relative to a landmark is specified by:
-  * Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
-  * Specifying the direction and distance from the landmark to the body location. 
+  1. Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
+  2. Specifying the direction and distance from the landmark to the body location. 
 
 Note that BodyLocation is a data type (a reusable structure), not a stand-alone entity. The concept is similar to how a postal address can apply to a person, location, or organization. This contrasts with FHIR's stand-alone BodySite (aka BodyStructure in r4) which 'is not ... intended for describing the type of anatomical location but rather a specific body site on a specific patient' (FHIR 3.5)."
 Includes codes descending from SCT#272424004 "Relative sites (qualifier value)"
@@ -342,8 +342,8 @@ Description:    "The type of feature that constitutes the landmark, for example,
 * Code only: The code should include (precoordinate) laterality and/orientation to the degree necessary to completely specify the body location.
 * Code plus laterality and/or orientation: The basic code augmented by codes specifying the body side and/or anatomical orientation.
 * Relation to landmark: The location relative to a landmark is specified by:
-  * Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
-  * Specifying the direction and distance from the landmark to the body location. 
+  1. Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
+  2. Specifying the direction and distance from the landmark to the body location. 
 
 Note that BodyLocation is a data type (a reusable structure), not a stand-alone entity. The concept is similar to how a postal address can apply to a person, location, or organization. This contrasts with FHIR's stand-alone BodySite (aka BodyStructure in r4) which 'is not ... intended for describing the type of anatomical location but rather a specific body site on a specific patient' (FHIR 3.5)."
 SCT#361083003       "Normal anatomy (body structure)"

--- a/spec/obf_datatype.txt
+++ b/spec/obf_datatype.txt
@@ -17,8 +17,8 @@ Description:       "A location or structure in the body, including tissues, regi
 * Code only: The code should include (precoordinate) laterality and/orientation to the degree necessary to completely specify the body location.
 * Code plus laterality and/or orientation: The basic code augmented by codes specifying the body side and/or anatomical orientation.
 * Relation to landmark: The location relative to a landmark is specified by:
-  * Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
-  * Specifying the direction and distance from the landmark to the body location.
+  1. Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
+  2. Specifying the direction and distance from the landmark to the body location.
 Note that BodyLocation is a data type, a reusable structure, not a stand-alone entity. The concept is similar to how a postal address can apply to a person, location, or organization. This contrasts with FHIR's stand-alone BodySite (aka BodyStructure in r4) which 'is not ... intended for describing the type of anatomical location but rather a specific body site on a specific patient' (FHIR 3.5)."
 Property:          Code 1..1
 Property:          Laterality 0..1
@@ -620,8 +620,8 @@ The laterality element is part of BodyLocation, a flexible structure that allows
 * Code only: The code should include (precoordinate) laterality and/orientation to the degree necessary to completely specify the body location.
 * Code plus laterality and/or orientation: The basic code augmented by codes specifying the body side and/or anatomical orientation.
 * Relation to landmark: The location relative to a landmark is specified by:
-  * Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
-  * Specifying the direction and distance from the landmark to the body location.
+  1. Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
+  2. Specifying the direction and distance from the landmark to the body location.
 
 Note that BodyLocation is a data type (a reusable structure), not a stand-alone entity. The concept is similar to how a postal address can apply to a person, location, or organization. This contrasts with FHIR's stand-alone BodySite (aka BodyStructure in r4) which 'is not ... intended for describing the type of anatomical location but rather a specific body site on a specific patient' (FHIR 3.5)."
 Value:             concept from http://hl7.org/fhir/ValueSet/bodysite-laterality (extensible)
@@ -633,8 +633,8 @@ The orientation element is part of BodyLocation, a flexible structure that allow
 * Code only: The code should include (precoordinate) laterality and/orientation to the degree necessary to completely specify the body location.
 * Code plus laterality and/or orientation: The basic code augmented by codes specifying the body side and/or anatomical orientation.
 * Relation to landmark: The location relative to a landmark is specified by:
-  * Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
-  * Specifying the direction and distance from the landmark to the body location.
+  1. Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
+  2. Specifying the direction and distance from the landmark to the body location.
 
 Note that BodyLocation is a data type (a reusable structure), not a stand-alone entity. The concept is similar to how a postal address can apply to a person, location, or organization. This contrasts with FHIR's stand-alone BodySite (aka BodyStructure in r4) which 'is not ... intended for describing the type of anatomical location but rather a specific body site on a specific patient' (FHIR 3.5)."
 Value:             concept from AnatomicalOrientationVS (extensible)
@@ -650,8 +650,8 @@ The RelationToLandmark element is part of BodyLocation, a flexible structure tha
 * Code only: The code should include (precoordinate) laterality and/orientation to the degree necessary to completely specify the body location.
 * Code plus laterality and/or orientation: The basic code augmented by codes specifying the body side and/or anatomical orientation.
 * Relation to landmark: The location relative to a landmark is specified by:
-  * Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
-  * Specifying the direction and distance from the landmark to the body location.
+  1. Establishing the location and type of landmark using a body site code and optional laterality/orientation, and 
+  2. Specifying the direction and distance from the landmark to the body location.
 
 Note that BodyLocation is a data type (a reusable structure), not a stand-alone entity. The concept is similar to how a postal address can apply to a person, location, or organization. This contrasts with FHIR's stand-alone BodySite (aka BodyStructure in r4) which 'is not ... intended for describing the type of anatomical location but rather a specific body site on a specific patient' (FHIR 3.5)."
 Property:          LandmarkType 0..1


### PR DESCRIPTION
- replaced sub-bullets with sub-numbers (MCODE-43);
- fixed PrimaryCancerConditionExamples in R4 and DSTU2 to align with removal of DataOfDiagnosis-extension from the mCODE model;
- added documentation on representing TNM staging category values (MCODE-33).