### PR TITLE
Fixed slice discriminators for DiagnosticReport and Observation

### DIFF
--- a/spec/obf_finding_map_r4.txt
+++ b/spec/obf_finding_map_r4.txt
@@ -33,7 +33,7 @@ Observation maps to Observation:
 	ReferenceRange.ApplicableSubpopulation maps to referenceRange.appliesTo
 	ReferenceRange.ApplicableAgeRange maps to referenceRange.age
 	ReferenceRange.Text maps to referenceRange.text
-	PanelMembers.Observation maps to hasMember (slice on = reference.resolve(); slice on type = profile; slice strategy = includes)
+	PanelMembers.Observation maps to hasMember (slice on = $this.resolve().code.coding.code; slice strategy = includes)
 	ObservationDerivedFrom maps to derivedFrom
 	Components.ObservationComponent maps to component (slice on = code.coding.code; slice strategy = includes)
 	Components.ObservationComponent.Code maps to component.code
@@ -103,7 +103,7 @@ DiagnosticReport maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core
 	DiagnosticReportPerformer maps to performer
 	ResultsInterpreter maps to resultsInterpreter
 	Specimen maps to specimen
-	Observation maps to result (slice on = reference.resolve(); slice on type = profile; slice strategy = includes)
+	Observation maps to result (slice on = $this.resolve().code.coding.code; slice strategy = includes)
 	MediaIncluded.CommentOrDescription maps to media.comment
 	MediaIncluded.Media maps to media.link
     ConclusionText maps to conclusion
@@ -134,7 +134,7 @@ LaboratoryReport maps to http://hl7.org/fhir/us/core/StructureDefinition/us-core
 	DiagnosticReportPerformer maps to performer
 	ResultsInterpreter maps to resultsInterpreter
 	Specimen maps to specimen
-	Observation maps to result (slice on = target.reference.resolve(); slice on type = profile; slice strategy = includes)
+	Observation maps to result (slice on = $this.resolve().code.coding.code; slice strategy = includes)
 	MediaIncluded.CommentOrDescription maps to media.comment
 	MediaIncluded.Media maps to media.link
     ConclusionText maps to conclusion


### PR DESCRIPTION
Also fixes TNMClinicalCancerStageGroup, TNMPathologicCancerStageGroup, and GenomicsReport FHIR R4 examples.