### PR TITLE
Update the BP component mappings

### DIFF
--- a/spec/vital_map_r4.txt
+++ b/spec/vital_map_r4.txt
@@ -11,6 +11,9 @@ BodyWeight maps to http://hl7.org/fhir/StructureDefinition/bodyweight:
 BodyHeight maps to http://hl7.org/fhir/StructureDefinition/bodyheight:
 
 BloodPressure maps to http://hl7.org/fhir/StructureDefinition/bp:
+// Re-map the components below to existing slices in the BP profile (requires SHR-CLI 6.5 and above)
+Components.SystolicPressure maps to component (slice # = 1)
+Components.DiastolicPressure maps to component (slice # = 2)
 
 RespiratoryRate maps to http://hl7.org/fhir/StructureDefinition/resprate:
 


### PR DESCRIPTION
Map SystolicPressure / DiastolicPressure to the existing slices in the BP profile.  This mapping uses new capability introduced in SHR-CLI 6.5 and eliminates the duplicated slices that earlier versions produced.