### PR TITLE
Agnosticize value set bindings between DSTU2 and R4

### DIFF
--- a/spec/ns-obf/obf-entity.txt
+++ b/spec/ns-obf/obf-entity.txt
@@ -413,8 +413,9 @@ Property:          AvailabilityExceptions 0..1
                    Status from http://hl7.org/fhir/ValueSet/location-status (required)
                    PartOf[Resource] substitute Location
                    Mode from http://hl7.org/fhir/ValueSet/location-mode (required)
-                   //Type from http://hl7.org/fhir/ValueSet/v3-ServiceDeliveryLocationRoleType (extensible)
-                   Type from http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType (extensible)
+                   // Conformance: terminology binding incompatibility between DSTU2 and R4. Leaving binding to mapping.
+                   // Type from http://hl7.org/fhir/ValueSet/v3-ServiceDeliveryLocationRoleType (extensible) // DSTU2
+                   // Type from http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType (extensible) //R4
 
                    // endpoint - not implemented
 Element:           OperationalStatus
@@ -502,7 +503,9 @@ Property:          Ingredient 0..*
 Property:          LotNumber 0..1
 Property:          ExpirationDate 0..1
                    Status from http://hl7.org/fhir/ValueSet/medication-status (required)
-                   Code from http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes (extensible)
+                   // Conformance: terminology binding incompatibility between argo (DSTU2) and us-core (R4). Leaving binding to mapping.
+                   // Code from  http://fhir.org/guides/argonaut/ValueSet/medication-codes (extensible) // argo (DSTU2)
+                   // Code from http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes (extensible) // us-core (R4)
 
 Element:           DoseForm
 Concept:           MTH#C0013058
@@ -607,6 +610,7 @@ Description:       "The sequence number for this specimen in a collection of spe
 Value:             concept
 
                    // BALLOT: Why is SpecimenContainer.SequenceNumber a concept? It should be an integer or a string. I don't think the sequence number will ever be coded, and concept is specifically designed for code mapping.
+
 Entry:             Device
 Parent:            Entity
 Description:       "A specific durable physical device used in diagnosis or treatment. The value is the coding for a type of device, for example, a CPAP machine. The same device might be used on multiple patients.
@@ -638,9 +642,13 @@ Property:          Url 0..1
 Property:          Annotation 0..*
 Property:          Safety 0..*
                    PartOf[Resource] substitute Device
-                   //			Status from http://hl7.org/fhir/ValueSet/devicestatus in V2 argo, http://hl7.org/fhir/ValueSet/device-status in us-core
+                   //Conformance: terminology binding incompatibility between DSTU2 and R4. Leaving binding to mapping.
+                   //Status from http://hl7.org/fhir/ValueSet/devicestatus (required) //DSTU2
+                   //Status from http://hl7.org/fhir/ValueSet/device-status (required) //R4
                    StatusReason from http://hl7.org/fhir/ValueSet/device-status-reason (extensible)
-                   Type from http://hl7.org/fhir/ValueSet/device-kind (required)
+                   // Conformance: terminology binding incompatibility between argo and FHIR R4. Leaving binding to mapping.
+                   // Type from http://fhir.org/guides/argonaut/ValueSet/device-kind (extensible) // argo (DSTU2)
+                   // Type from http://hl7.org/fhir/ValueSet/device-kind (required)  // us-core (R4)
 
 Group:             UdiCarrier
 Description:       "Structure of the Unique Device Identifier (UDI) Barcode string number for a device, assigned by the organization using the device."

--- a/spec/ns-obf/obf-finding.txt
+++ b/spec/ns-obf/obf-finding.txt
@@ -43,7 +43,9 @@ Property:          DateOfDiagnosis 0..1
                    SubjectOfRecord only Patient
                    CareContext only Encounter
                    // cannot make the binding weaker because US Core requires an extensible binding
-                   Code from http://hl7.org/fhir/us/core/ValueSet/us-core-problem (extensible)
+                   //Conformance: terminology binding incompatibility between argo (DSTU2) and us-core (R4). Leaving binding to mapping.
+                   // Code from http://hl7.org/fhir/ValueSet/daf-problem (extensible)
+                   // Code from http://hl7.org/fhir/us/core/ValueSet/us-core-problem (extensible)
                    ClinicalStatus from http://hl7.org/fhir/ValueSet/condition-clinical (required)
                    // category is 1..1 in Argonaut
                    Category from http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category (extensible)
@@ -314,7 +316,10 @@ Description:       "An observation whose result is a code, and also having no co
 
 Element:           DataAbsentReason
 Description:       "Reason that a value associated with a test or other finding is missing."
-Value:             concept from http://hl7.org/fhir/ValueSet/data-absent-reason (extensible)
+Value:             concept
+                    // Conformance: terminology binding incompatibility between DSTU2 and R4. Leaving binding to mapping.
+                    // concept from http://hl7.org/fhir/ValueSet/observation-valueabsentreason (extensible) // DSTU2
+                    // concept from http://hl7.org/fhir/ValueSet/data-absent-reason (extensible) // R4
 
 Group:             ReferenceRange
 Concept:           MTH#C0883335

--- a/spec/ns-obf/obf-medication.txt
+++ b/spec/ns-obf/obf-medication.txt
@@ -90,7 +90,10 @@ Property:          Dosage 0..1
 Element:           MedicationCodeOrReference
 Description:       "A choice of a medication code or reference."
 //Value:             concept from http://h7.org/fhir/us/core/ValueSet/us-core-medication-codes (extensible) or Medication
-Value:             concept from http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes (extensible) or Medication
+Value:             concept or Medication
+                    // Conformance: terminology binding incompatibility between argo (DSTU2) and us-core (R4). Leaving binding to mapping.
+                    // concept from  http://fhir.org/guides/argonaut/ValueSet/medication-codes (extensible)  or Medication // argo (DSTU2)
+                    // concept from http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes (extensible)  or Medication // us-core (R4) 
 
 Entry:             MedicationStatement
 Parent:            MedicationAction

--- a/spec/ns-obf/obf-procedure.txt
+++ b/spec/ns-obf/obf-procedure.txt
@@ -47,7 +47,9 @@ Property:          UsedCode 0..*
                    Participation.OnBehalfOf only Organization
                    // Procedure doesn't have Method
                    Method 0..0
-                   Code from http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code (extensible)
+                   // Conformance: terminology binding incompatibility between argo (DSTU2) and us-core (R4). Leaving binding to mapping.
+                   // Code from http://fhir.org/guides/argonaut/ValueSet/procedure-type (extensible) // argo (DSTU2)
+                   // Code from http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code (extensible) // us-core (R4)
                    Outcome from http://hl7.org/fhir/ValueSet/procedure-outcome (example)
 
 Entry:             SurgicalProcedure
@@ -139,7 +141,9 @@ Property:          PartOf 0..1
 Property:          Method 0..1
                    PartOf[Resource] substitute Procedure
                    ReasonReference substitute ProcedureRequestReasonReference
-                   Code from http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code (extensible)
+                   // Conformance: terminology binding incompatibility between argo (DSTU2) and us-core (R4). Leaving binding to mapping.
+                   // Code from http://fhir.org/guides/argonaut/ValueSet/procedure-type (extensible) // argo (DSTU2)
+                   // Code from http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code (extensible) // us-core (R4)
                    // this is a constraint on the cardinality of Action.Category
                    // limit upper card to 1 in DSTU2
                    //0..*			InputFinding  -- covered by Reason


### PR DESCRIPTION
Note these fixes are R4 and DSTU2-compatible, so we should merge these to `dev6` before attempting to create a DSTU-2 specific branch.

Note that there will be some errors in this code related to code system declaration, which is a fix that we should only apply in a DSTU-2 specific branch. Those changes are included in the branch [dev6-dstu2](https://github.com/standardhealth/shr_spec/tree/dev6-dstu2), which also includes the changes in this PR and compiles cleanly. The `dev6-dstu2` branch is not intended to be merged onto dev6.